### PR TITLE
Add intro animations, nav refinements, and back links

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -225,6 +225,25 @@ span.project-subheader {
 .greedy-nav a:hover {
     // color:#9C7A00 !important; not the vibe anymore
 }
+.site-title {
+    font-size: 1em !important;
+    font-weight: 700 !important;
+    letter-spacing: -0.01em;
+}
+.masthead__menu-item a {
+    font-size: 0.8em !important;
+    font-weight: 400 !important;
+    color: #999 !important;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    transition: color 0.2s ease;
+}
+.masthead__menu-item a:hover {
+    color: #333 !important;
+}
+body.layout--default .masthead__menu-item a[href="/info"] {
+    display: none;
+}
 
 .notice--primary {
     display: table-cell; /* this helped to dodge the issue of the notice not wrapping when i had image on right */
@@ -273,6 +292,17 @@ span.project-subheader {
     visibility: hidden;
     display:block;
     width: 0px !important;
+}
+
+/* ── Intro word stagger ── */
+.word-pop {
+    display: inline-block;
+    opacity: 0;
+    animation: word-pop 0.5s ease-out forwards;
+}
+@keyframes word-pop {
+    0%   { opacity: 0; transform: translateY(12px); }
+    100% { opacity: 1; transform: translateY(0); }
 }
 
 /* ── Project tile grid animations ── */

--- a/index.md
+++ b/index.md
@@ -32,7 +32,14 @@ galleryProjects:
 
 <!-- <img src="../assets/img/profile-pic.jpg" style="overflow:hidden; border-radius:500px; height:200px; width:200px; float: left; margin-right:20px;"><br> -->
 <br>
-<center><h1>Empathy, collaboration, iteration, delight. <br><a href="info.html">Rinse & Repeat</a>.</h1></center>
+<h1 style="text-align:center; text-wrap:balance;">
+  <span class="word-pop" style="animation-delay:0.0s">Empathy,</span>
+  <span class="word-pop" style="animation-delay:0.4s">collaboration,</span>
+  <span class="word-pop" style="animation-delay:0.8s">iteration,</span>
+  <span class="word-pop" style="animation-delay:1.2s">delight.</span>
+  <br>
+  <span class="word-pop" style="animation-delay:1.8s"><a href="info.html">Rinse &amp; Repeat</a>.</span>
+</h1>
 <br>
 
 <span class="project-subheader" style="display:block;padding-bottom:20px;text-align:center;width:100%;">My Projects</span>

--- a/info.md
+++ b/info.md
@@ -1,6 +1,8 @@
 ---
 hide_footer: true
 ---
+<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+
 # Hello!
 
 ![Justin Pocta](../assets/img/Info-Justin-Pocta.jpg)

--- a/opengov.md
+++ b/opengov.md
@@ -88,6 +88,8 @@ galleryIA:
     alt: "DESCRIPTION"
 ---
 
+<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+
 # OpenGov Projects
 *Senior Product Designer, Budgeting - 2021-22*
 {: .notice}

--- a/smartling-jobs.md
+++ b/smartling-jobs.md
@@ -61,6 +61,8 @@ galleryFinal:
     alt: " "
     title: " "
 ---
+<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+
 # Project: Jobs Dashboard
 *Product Designer @ Smartling, 2017-21*
 {: .notice}

--- a/smartling-transcreation.md
+++ b/smartling-transcreation.md
@@ -28,6 +28,8 @@ galleryIterations:
     title: ""
 
 ---
+<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+
 # Project: Transcreation Tool
 *Product Designer @ Smartling, 2017-21*
 {: .notice}

--- a/smartling-workflows.md
+++ b/smartling-workflows.md
@@ -59,6 +59,8 @@ galleryDecisionStepRules:
     title: ""
 ---
 
+<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+
 # Project: Workflows 2.0
 *Product Designer @ Smartling, 2017-21*
 {: .notice}


### PR DESCRIPTION
## Summary

- Staggered word-by-word fade-up on homepage headline, with "Rinse & Repeat" arriving last as a punchline
- `text-wrap: balance` on headline for cleaner line breaks at all widths
- Bold site title, quiet uppercase "Info" nav link with smooth hover
- "Info" nav link hidden on interior pages (project pages + info page)
- `← Back` link added to info page and all 4 project pages, styled to match nav

## Test plan

- [ ] Homepage headline animates in word by word on load
- [ ] Mobile headline wraps evenly (no orphaned words)
- [ ] "Info" nav link visible on homepage, hidden on project/info pages
- [ ] `← Back` link appears on info + all 4 project pages and navigates to homepage
- [ ] Hover states work on both nav link and back link

🤖 Generated with [Claude Code](https://claude.com/claude-code)