### PR TITLE
Redesign tile labels, wayfinding animation, and nav polish

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,8 +33,8 @@ github_username:  justinpocta
 # exclude: [vendor]
 # this was a recommendation to get around issues with invalid date when launching jekyll server https://github.com/jekyll/jekyll/issues/5267
 
-name: Justin Pocta, Product Designer.
-title: Justin Pocta, Product Designer.
+name: Justin Pocta
+title: Justin Pocta
 github:
  resume_url: https://github.com/justinpocta/justinpocta.com/raw/master/2023-Pocta-Resume.pdf
 

--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -5,15 +5,11 @@
     <div class="css-anim">
       <div class="anim-og">
         <div class="og-row">
-          <div class="og-dot og-dot-1"></div>
-          <div class="og-add og-add-2">
-            <span class="og-arrow">&#x2192;</span>
-            <div class="og-dot og-dot-2"></div>
-          </div>
-          <div class="og-add og-add-3">
-            <span class="og-arrow">&#x2192;</span>
-            <div class="og-dot og-dot-3"></div>
-          </div>
+          <div class="og-cell og-dot-cell og-dc-1"><div class="og-dot og-dot-1"></div></div>
+          <div class="og-cell og-arrow-cell og-ac-1"><span class="og-arrow-inner og-arrow-inner-1">&#x2192;</span></div>
+          <div class="og-cell og-dot-cell og-dc-2"><div class="og-dot og-dot-2"></div></div>
+          <div class="og-cell og-arrow-cell og-ac-2"><span class="og-arrow-inner og-arrow-inner-2">&#x2192;</span></div>
+          <div class="og-cell og-dot-cell og-dc-3"><div class="og-dot og-dot-3"></div></div>
         </div>
       </div>
     </div>
@@ -175,6 +171,7 @@
 
 <script>
   (function() {
+    if (!window.matchMedia('(hover: none)').matches) return;
     var tiles = document.querySelectorAll('.video-container');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
@@ -183,7 +180,7 @@
           observer.unobserve(entry.target);
         }
       });
-    }, { threshold: 0.2 });
+    }, { threshold: 0.5 });
     tiles.forEach(function(tile) { observer.observe(tile); });
   })();
 </script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -241,7 +241,13 @@ span.project-subheader {
 .masthead__menu-item a:hover {
     color: #333 !important;
 }
-body.layout--default .masthead__menu-item a[href="/info"] {
+.masthead__menu-item a[href="/info"]:hover {
+    color: #B8963A !important;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-color: #B8963A;
+}
+body.page--info .masthead__menu-item a[href="/info"] {
     display: none;
 }
 
@@ -430,31 +436,77 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
 
 /* OG — Wayfinding */
 .anim-og { width: 100%; height: 72px; display: flex; align-items: center; justify-content: center; }
-.og-row { display: flex; align-items: center; opacity: 0; animation: og-row 6s ease-in-out infinite; }
+.og-row { display: flex; align-items: center; }
+.og-cell { display: flex; align-items: center; justify-content: center; flex-shrink: 0; overflow: hidden; }
+.og-dot-cell { width: 38px; height: 38px; }
+.og-arrow-cell { height: 38px; width: 72px; }
+.og-dc-1 { width: 38px; }
+.og-dc-2 { max-width: 0; animation: og-dcell2 6s ease-in-out infinite; }
+.og-dc-3 { max-width: 0; animation: og-dcell3 6s ease-in-out infinite; }
+.og-ac-1 { max-width: 0; animation: og-acell1 6s ease-in-out infinite; }
+.og-ac-2 { max-width: 0; animation: og-acell2 6s ease-in-out infinite; }
 .og-dot { width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0; }
-.og-dot-1 { background: #2563EB; }
-.og-dot-2 { background: #93C5FD; }
-.og-dot-3 { background: #BFDBFE; }
-.og-arrow { color: #64748B; font-size: 26px; line-height: 1; flex-shrink: 0; margin-left: 20px; }
-.og-add { display: flex; align-items: center; gap: 20px; overflow: hidden; max-width: 0; flex-shrink: 0; }
-.og-add-2 { animation: og-add2 6s linear infinite; }
-.og-add-3 { animation: og-add3 6s linear infinite; }
+.og-dot-1 { background: #2563EB; animation: og-dot1 6s ease-in-out infinite; }
+.og-dot-2 { background: #93C5FD; animation: og-dot2 6s ease-in-out infinite; }
+.og-dot-3 { background: #BFDBFE; animation: og-dot3 6s ease-in-out infinite; }
+.og-arrow-inner { color: #64748B; font-size: 22px; line-height: 1; flex-shrink: 0; }
+.og-arrow-inner-1 { animation: og-arrow1 6s ease-in-out infinite; }
+.og-arrow-inner-2 { animation: og-arrow2 6s ease-in-out infinite; }
 
-@keyframes og-row {
-    0%, 8%    { opacity: 0; }
-    16%       { opacity: 1; }
-    76%       { opacity: 1; }
-    86%, 100% { opacity: 0; }
+@keyframes og-dot1 {
+    0%, 76%     { transform: scale(1); }
+    82%         { transform: scale(1.18); }
+    88%, 94%    { transform: scale(0); }
+    97%         { transform: scale(1.22); }
+    100%        { transform: scale(1); }
 }
-@keyframes og-add2 {
-    0%, 28%   { max-width: 0; animation-timing-function: cubic-bezier(0, 0, 0.2, 1); }
-    32%, 85%  { max-width: 120px; }
-    86%, 100% { max-width: 0; }
+@keyframes og-arrow1 {
+    0%, 12%     { transform: scale(0); opacity: 0; }
+    15%         { transform: scale(1.22); opacity: 1; }
+    18%, 76%    { transform: scale(1); opacity: 1; }
+    82%         { transform: scale(1.18); opacity: 1; }
+    88%, 100%   { transform: scale(0); opacity: 0; }
 }
-@keyframes og-add3 {
-    0%, 48%   { max-width: 0; animation-timing-function: cubic-bezier(0, 0, 0.2, 1); }
-    52%, 85%  { max-width: 120px; }
-    86%, 100% { max-width: 0; }
+@keyframes og-dot2 {
+    0%, 15%     { transform: scale(0); }
+    18%         { transform: scale(1.22); }
+    21%, 76%    { transform: scale(1); }
+    82%         { transform: scale(1.18); }
+    88%, 100%   { transform: scale(0); }
+}
+@keyframes og-arrow2 {
+    0%, 30%     { transform: scale(0); opacity: 0; }
+    33%         { transform: scale(1.22); opacity: 1; }
+    36%, 76%    { transform: scale(1); opacity: 1; }
+    82%         { transform: scale(1.18); opacity: 1; }
+    88%, 100%   { transform: scale(0); opacity: 0; }
+}
+@keyframes og-dot3 {
+    0%, 33%     { transform: scale(0); }
+    36%         { transform: scale(1.22); }
+    39%, 76%    { transform: scale(1); }
+    82%         { transform: scale(1.18); }
+    88%, 100%   { transform: scale(0); }
+}
+@keyframes og-acell1 {
+    0%, 10%     { max-width: 0; animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+    19%, 87%    { max-width: 72px; animation-timing-function: cubic-bezier(0.4, 0, 1, 1); }
+    90%, 100%   { max-width: 0; }
+}
+@keyframes og-acell2 {
+    0%, 28%     { max-width: 0; animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+    37%, 87%    { max-width: 72px; animation-timing-function: cubic-bezier(0.4, 0, 1, 1); }
+    90%, 100%   { max-width: 0; }
+}
+@keyframes og-dcell2 {
+    0%, 13%     { max-width: 0; animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+    22%, 87%    { max-width: 38px; animation-timing-function: cubic-bezier(0.4, 0, 1, 1); }
+    90%, 100%   { max-width: 0; }
+}
+@keyframes og-dcell3 {
+    0%, 31%     { max-width: 0; animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+    40%, 87%    { max-width: 38px; animation-timing-function: cubic-bezier(0.4, 0, 1, 1); }
+    90%, 100%   { max-width: 0; }
 }
 
 /* Jobs */

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
-Name: Justin Pocta, Product Designer.
-Title: Justin Pocta, Product Designer.
+Name: Justin Pocta
+Title: Justin Pocta
 layout: front
 hide_footer: true
 galleryProjects:
@@ -38,11 +38,11 @@ galleryProjects:
   <span class="word-pop" style="animation-delay:0.8s">iteration,</span>
   <span class="word-pop" style="animation-delay:1.2s">delight.</span>
   <br>
-  <span class="word-pop" style="animation-delay:1.8s"><a href="info.html">Rinse &amp; Repeat</a>.</span>
+  <span class="word-pop" style="animation-delay:1.8s"><a href="info.html" style="color:#B8963A;">Rinse &amp; Repeat</a>.</span>
 </h1>
 <br>
 
-<span class="project-subheader" style="display:block;padding-bottom:20px;text-align:center;width:100%;">My Projects</span>
+<span class="project-subheader" style="display:block;padding-bottom:20px;text-align:center;width:100%;">Product Design — Select Projects</span>
 {% include anim-01.html %}
 
 <div style="padding-bottom: 40px;"></div>

--- a/info.md
+++ b/info.md
@@ -1,5 +1,6 @@
 ---
 hide_footer: true
+body_class: page--info
 ---
 <a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
 
@@ -8,7 +9,7 @@ hide_footer: true
 ![Justin Pocta](../assets/img/Info-Justin-Pocta.jpg)
 {: .fifty-right}
 
-*I'm a Sr. Product Designer @ [Highlight](https://www.letshighlight.com)*
+*I'm a Sr. Product Designer @ <a href="https://www.letshighlight.com" style="color:#B8963A;">Highlight</a>*
 
 One of my major passions is applying my design skills toward the refinement and clarity of a digital project's experience. My obsession with constantly learning more has led me, project-by-project, to being increasingly human-centered in my process and what I see as necessary for an app or website to be truly _successful_. Helping useful tools become more enjoyable and easier to understand is what I strive to do.
 


### PR DESCRIPTION
## Summary
- Tile labels restructured: company name stacked above project title, both fade in on hover with logo always visible
- Wayfinding animation fully redesigned: flat cell structure, per-element scale pop animations (1.22 overshoot), smooth max-width expansion for dynamic recentering as elements appear
- Highlight SVG logo gets unified brand gradient (45deg) across the entire SVG using userSpaceOnUse
- Gold `#B8963A` applied to Rinse & Repeat link, Info nav hover underline, and Highlight link on info page
- Info nav link now visible on project pages; hidden only on the info page itself via `body_class: page--info`
- Site title → Justin Pocta; section header → Product Design — Select Projects
- Mobile greyscale IntersectionObserver guarded to `hover: none` devices only (threshold 0.5)

## Test plan
- [ ] Hover each tile — company name and project title fade in, logo stays visible
- [ ] Wayfinding animation: dots and arrows pop in sequentially, row recenters dynamically, all fade out cleanly
- [ ] Highlight logo spins with the brand gradient across the full SVG
- [ ] Rinse & Repeat, Info nav hover, and Highlight links all show gold
- [ ] INFO link appears on project pages, disappears on the info page itself
- [ ] On mobile (touch device): tiles start greyscale, colorize as they scroll into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)