### PR TITLE
Mobile UX: taller hero, taller tiles, greyscale scroll reset

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -177,7 +177,8 @@
       entries.forEach(function(entry) {
         if (entry.isIntersecting) {
           entry.target.classList.add('in-view');
-          observer.unobserve(entry.target);
+        } else {
+          entry.target.classList.remove('in-view');
         }
       });
     }, { threshold: 0.5 });

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -30,6 +30,9 @@ body.layout--front .container {
     max-width: 1080px;
     display: block;
 }
+.hero-intro {
+    padding-top: 3rem;
+}
 body.layout--front figure {
     margin: 0 !important;
     // justify-content: unset !important;
@@ -426,7 +429,14 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
 }
 
 @media (max-width: 768px) {
-    .video-container { width: 100%; min-height: 60vw; max-height: none; }
+    .hero-intro {
+        min-height: 65vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .hero-intro h1 { margin: 0; }
+    .video-container { width: 100%; min-height: 80vw; max-height: none; }
     .video-container p { padding-bottom: 1.3em; }
 }
 

--- a/index.md
+++ b/index.md
@@ -31,6 +31,7 @@ galleryProjects:
 ---
 
 <!-- <img src="../assets/img/profile-pic.jpg" style="overflow:hidden; border-radius:500px; height:200px; width:200px; float: left; margin-right:20px;"><br> -->
+<div class="hero-intro">
 <br>
 <h1 style="text-align:center; text-wrap:balance;">
   <span class="word-pop" style="animation-delay:0.0s">Empathy,</span>
@@ -41,6 +42,7 @@ galleryProjects:
   <span class="word-pop" style="animation-delay:1.8s"><a href="info.html" style="color:#B8963A;">Rinse &amp; Repeat</a>.</span>
 </h1>
 <br>
+</div>
 
 <span class="project-subheader" style="display:block;padding-bottom:20px;text-align:center;width:100%;">Product Design — Select Projects</span>
 {% include anim-01.html %}


### PR DESCRIPTION
## Summary
- Hero intro area gets `65vh` min-height on mobile with flex centering; `3rem` top padding added on desktop for better visual balance
- Project tiles bumped from `60vw` to `80vw` min-height on mobile so animations have more room
- IntersectionObserver now removes `in-view` when tiles scroll out of view, returning them to greyscale/paused state

## Test plan
- [ ] On mobile: hero text area fills ~65% of screen with tiles peeking below
- [ ] On mobile: scrolling past a tile returns it to greyscale with animation paused; scrolling back colorizes it again
- [ ] On desktop: hero text has balanced spacing above and below, layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)