### PR TITLE
Add Highlight page, fix nav underline animations, hero gradient polish

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -177,7 +177,8 @@
       entries.forEach(function(entry) {
         if (entry.isIntersecting) {
           entry.target.classList.add('in-view');
-          observer.unobserve(entry.target);
+        } else {
+          entry.target.classList.remove('in-view');
         }
       });
     }, { threshold: 0.5 });

--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -150,7 +150,7 @@
   </a>
 
   <!-- Highlight / Coming Soon -->
-  <div class="video-container" style="background-color:#0F0F0F; width:100%;">
+  <a href="/highlight" class="video-container" style="background-color:#0F0F0F; width:100%;">
     <div class="css-anim">
       <img src="/assets/img/highlight-logo.svg" class="hl-spin" alt="Highlight logo">
     </div>
@@ -161,11 +161,11 @@
         </div>
         <div class="tile-text">
           <div class="tile-company" style="color:white;">Highlight</div>
-          <div class="project-title-name" style="color:white;">Coming Soon</div>
+          <div class="project-title-name" style="color:white;">Recent Work</div>
         </div>
       </div>
     </div>
-  </div>
+  </a>
 
 </div>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,6 +13,38 @@ search: false
 @import '../css/ibm-plex.min.css';
 
 
+body.layout--front::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: linear-gradient(to bottom, rgba(184, 150, 58, 0.12), rgba(184, 150, 58, 0) 60%);
+    pointer-events: none;
+    z-index: 0;
+}
+body.layout--front .masthead {
+    position: relative;
+    z-index: 1;
+    background-color: #fff;
+}
+body.page--info::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: linear-gradient(to bottom, rgba(100, 116, 139, 0.12), rgba(100, 116, 139, 0) 60%);
+    pointer-events: none;
+    z-index: 0;
+}
+body.page--info .masthead {
+    position: relative;
+    z-index: 1;
+    background-color: #fff;
+}
 body.layout--front .initial-content {
     width: 100% !important;
     max-width: none !important;
@@ -232,6 +264,17 @@ span.project-subheader {
     font-size: 1em !important;
     font-weight: 700 !important;
     letter-spacing: -0.01em;
+    text-decoration: none !important;
+    background-image: linear-gradient(#B8963A, #B8963A);
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 2px;
+    padding-bottom: 3px;
+    transition: background-size 0.35s ease, color 0.35s ease !important;
+}
+.site-title:hover {
+    color: #B8963A !important;
+    background-size: 100% 2px;
 }
 .masthead__menu-item a {
     font-size: 0.8em !important;
@@ -244,14 +287,30 @@ span.project-subheader {
 .masthead__menu-item a:hover {
     color: #333 !important;
 }
+.rinse-repeat-link {
+    text-decoration: none;
+    background-image: linear-gradient(#B8963A, #B8963A);
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 2px;
+    padding-bottom: 3px;
+    transition: background-size 0.35s ease;
+}
+.rinse-repeat-link:hover {
+    background-size: 100% 2px;
+}
+.masthead__menu-item a[href="/info"] {
+    text-decoration: none !important;
+}
+.masthead__menu-item a[href="/info"]:before {
+    background: #B8963A !important;
+    height: 2px !important;
+    transform-origin: left !important;
+    transition: all 0.35s ease-in-out !important;
+}
 .masthead__menu-item a[href="/info"]:hover {
     color: #B8963A !important;
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    text-decoration-color: #B8963A;
-}
-body.page--info .masthead__menu-item a[href="/info"] {
-    display: none;
+    text-decoration: none !important;
 }
 
 .notice--primary {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -30,6 +30,9 @@ body.layout--front .container {
     max-width: 1080px;
     display: block;
 }
+.hero-intro {
+    padding-top: 3rem;
+}
 body.layout--front figure {
     margin: 0 !important;
     // justify-content: unset !important;
@@ -426,7 +429,14 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
 }
 
 @media (max-width: 768px) {
-    .video-container { width: 100%; min-height: 60vw; max-height: none; }
+    .hero-intro {
+        min-height: 65vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .hero-intro h1 { margin: 0; }
+    .video-container { width: 100%; min-height: 80vw; max-height: none; }
     .video-container p { padding-bottom: 1.3em; }
 }
 

--- a/highlight.md
+++ b/highlight.md
@@ -1,0 +1,25 @@
+---
+title: Highlight
+layout: default
+breadcrumbs: true
+toc: false
+---
+
+<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+
+# Highlight
+*Senior Product Designer, Jan 2024–Present*
+{: .notice}
+
+<span class="project-subheader">Coming Soon</span>
+# Recent Work
+{: .no_toc id="h1st"}
+
+<img src="/assets/img/highlight-logo.svg" style="height:120px; width:auto;" alt="Highlight">
+{: .third-right}
+
+I joined Highlight in January 2024 as a Senior Product Designer, focused on internal tools and our product testing platform. At the center of Highlight's unique positioning is a thoughtful and mission-driven community of Highlighters, real people who test products at home and send honest feedback straight to the brands that make them. My work centered on evolving a manual recruiting process into a powerful, targeted, automated system, and on modernizing the Highlighter experience.
+
+---
+
+**[← Back to Projects](/)**

--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ galleryProjects:
   <span class="word-pop" style="animation-delay:0.8s">iteration,</span>
   <span class="word-pop" style="animation-delay:1.2s">delight.</span>
   <br>
-  <span class="word-pop" style="animation-delay:1.8s"><a href="info.html" style="color:#B8963A;">Rinse &amp; Repeat</a>.</span>
+  <span class="word-pop" style="animation-delay:1.8s"><a href="info.html" class="rinse-repeat-link" style="color:#B8963A; font-size:1.15em; font-weight:600;">Rinse &amp; Repeat</a>.</span>
 </h1>
 <br>
 </div>

--- a/index.md
+++ b/index.md
@@ -31,6 +31,7 @@ galleryProjects:
 ---
 
 <!-- <img src="../assets/img/profile-pic.jpg" style="overflow:hidden; border-radius:500px; height:200px; width:200px; float: left; margin-right:20px;"><br> -->
+<div class="hero-intro">
 <br>
 <h1 style="text-align:center; text-wrap:balance;">
   <span class="word-pop" style="animation-delay:0.0s">Empathy,</span>
@@ -41,6 +42,7 @@ galleryProjects:
   <span class="word-pop" style="animation-delay:1.8s"><a href="info.html" style="color:#B8963A;">Rinse &amp; Repeat</a>.</span>
 </h1>
 <br>
+</div>
 
 <span class="project-subheader" style="display:block;padding-bottom:20px;text-align:center;width:100%;">Product Design — Select Projects</span>
 {% include anim-01.html %}

--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
 ---
 hide_footer: true
-body_class: page--info
+classes: page--info
 ---
 <a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
 
@@ -9,7 +9,7 @@ body_class: page--info
 ![Justin Pocta](../assets/img/Info-Justin-Pocta.jpg)
 {: .fifty-right}
 
-*I'm a Sr. Product Designer @ <a href="https://www.letshighlight.com" style="color:#B8963A;">Highlight</a>*
+*I'm a Sr. Product Designer @ <a href="https://www.letshighlight.com" class="rinse-repeat-link" style="color:#B8963A;">Highlight</a>*
 
 One of my major passions is applying my design skills toward the refinement and clarity of a digital project's experience. My obsession with constantly learning more has led me, project-by-project, to being increasingly human-centered in my process and what I see as necessary for an app or website to be truly _successful_. Helping useful tools become more enjoyable and easier to understand is what I strive to do.
 


### PR DESCRIPTION
## Summary
- New `/highlight` page: a short "Recent Work" intro covering the role and Highlighter community, linked from the homepage tile (previously "Coming Soon", now points here)
- Fixed a long-standing bug: `body_class` front matter was never actually wired into the layout (it reads `page.classes`) — switched `info.md` to use `classes`, so page-scoped CSS actually works now
- Info nav link, site title ("Justin Pocta"), and "Rinse & Repeat" all get a consistent animated gold underline that grows left-to-right on hover
- Fixed the theme's `.greedy-nav a { transition: none; }` silently killing custom hover transitions on nav links
- Info nav link now stays visible on the info page itself (previously hidden, but that never worked due to the body_class bug anyway)
- Subtle fading gradient behind hero content: ochre on the homepage, slate-blue-grey on the info page
- "Rinse & Repeat" bumped slightly in size/weight for personality

## Test plan
- [ ] Visit `/highlight` — intro renders, back link and homepage tile link work
- [ ] Hover "Justin Pocta", "Info", and "Rinse & Repeat" — all animate a gold underline left-to-right at the same speed
- [ ] Visit `/info` — Info nav link is visible, slate-blue-grey gradient shows behind content
- [ ] Homepage hero has ochre gradient fading out on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)