### PR TITLE
Add page transitions, Highlight social icons, and project nav links

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,33 @@
+<noscript><style>.initial-content { opacity: 1 !important; }</style></noscript>
+<script>
+(function() {
+  document.addEventListener('DOMContentLoaded', function() {
+    document.body.classList.add('page-loaded');
+  });
+
+  document.addEventListener('click', function(e) {
+    var a = e.target.closest('a');
+    if (!a) return;
+    if (a.target === '_blank' || a.hasAttribute('download')) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+
+    var href = a.getAttribute('href');
+    if (!href || href.charAt(0) === '#' || href.indexOf('mailto:') === 0 || href.indexOf('tel:') === 0) return;
+
+    var url;
+    try { url = new URL(href, window.location.href); } catch (err) { return; }
+    if (url.origin !== window.location.origin) return;
+    if (url.href === window.location.href) return;
+
+    e.preventDefault();
+    document.body.classList.remove('page-loaded');
+    document.body.classList.add('page-leaving');
+    setTimeout(function() { window.location.href = url.href; }, 220);
+  });
+
+  window.addEventListener('pageshow', function(e) {
+    document.body.classList.remove('page-leaving');
+    document.body.classList.add('page-loaded');
+  });
+})();
+</script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -12,6 +12,19 @@ search: false
 @import '../css/ibm-plex.css';
 @import '../css/ibm-plex.min.css';
 
+.initial-content {
+    opacity: 0;
+    transition: opacity 0.35s ease-out;
+}
+body.page-loaded .initial-content {
+    opacity: 1;
+    transition-delay: 0.12s;
+}
+body.page-leaving .initial-content {
+    opacity: 0;
+    transition-delay: 0s;
+}
+
 
 body.layout--front::before {
     content: "";
@@ -23,11 +36,36 @@ body.layout--front::before {
     background: linear-gradient(to bottom, rgba(184, 150, 58, 0.12), rgba(184, 150, 58, 0) 60%);
     pointer-events: none;
     z-index: 0;
+    opacity: 0;
+    transition: opacity 0.5s ease-out;
+}
+body.layout--front.page-loaded::before {
+    opacity: 1;
+}
+body.layout--front.page-leaving::before {
+    opacity: 0;
 }
 body.layout--front .masthead {
     position: relative;
     z-index: 1;
     background-color: #fff;
+}
+.masthead {
+    transform: translateY(-100%);
+    transition: transform 0.3s ease-out;
+}
+body.page-loaded .masthead {
+    transform: translateY(0);
+}
+body.page-leaving .masthead {
+    transform: translateY(-100%);
+}
+body:not(.layout--front) .masthead__inner-wrap {
+    padding-top: 0.6em;
+    padding-bottom: 0.6em;
+}
+body:not(.layout--front) .site-title {
+    font-size: 0.85em !important;
 }
 body.page--info::before {
     content: "";
@@ -39,6 +77,14 @@ body.page--info::before {
     background: linear-gradient(to bottom, rgba(100, 116, 139, 0.12), rgba(100, 116, 139, 0) 60%);
     pointer-events: none;
     z-index: 0;
+    opacity: 0;
+    transition: opacity 0.5s ease-out;
+}
+body.page--info.page-loaded::before {
+    opacity: 1;
+}
+body.page--info.page-leaving::before {
+    opacity: 0;
 }
 body.page--info .masthead {
     position: relative;

--- a/highlight.md
+++ b/highlight.md
@@ -1,5 +1,6 @@
 ---
 title: Highlight
+hide_footer: true
 layout: default
 breadcrumbs: true
 toc: false
@@ -22,4 +23,7 @@ I joined Highlight in January 2024 as a Senior Product Designer, focused on inte
 
 ---
 
-**[← Back to Projects](/)**
+<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
+  <a href="/smartling-transcreation" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
+  <a href="/info" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Info →</a>
+</div>

--- a/info.md
+++ b/info.md
@@ -15,8 +15,8 @@ One of my major passions is applying my design skills toward the refinement and 
 
 I love working with teams that value asking questions. _Why are we creating a given project? What is the objective and our goal? How could we achieve it differently, better, smarter, faster? What if we tried it another way?_ 
 
-<div style="border: 2px solid #D4B870; border-radius: 6px; padding: 28px; margin: 1.5em 0 40px; text-align: center; box-sizing: border-box; overflow: hidden;">
-  <p style="margin: 0 0 20px; font-weight: 400; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.1em; color: #999;">Get in Touch</p>
+<div style="border: 2px solid #D4B870; border-radius: 6px; padding: 26px 32px 32px; margin: 1.5em 0 40px; text-align: center; box-sizing: border-box; overflow: hidden;">
+  <p style="margin: 0 0 28px; font-weight: 400; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.1em; color: #999;">Get in Touch</p>
   <div style="display: flex; gap: 48px; justify-content: center;">
     <a href="mailto:howdy@justinpocta.com?subject=Hello" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">
       <i class="fas fa-envelope" style="font-size:1.5em;"></i>
@@ -25,6 +25,10 @@ I love working with teams that value asking questions. _Why are we creating a gi
     <a href="https://linkedin.com/in/justinpocta" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">
       <i class="fab fa-linkedin" style="font-size:1.5em;"></i>
       <span style="font-size:0.78em;">LinkedIn</span>
+    </a>
+    <a href="https://github.com/justinpocta" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">
+      <i class="fab fa-github" style="font-size:1.5em;"></i>
+      <span style="font-size:0.78em;">GitHub</span>
     </a>
     <a href="2026-Pocta-Resume.pdf" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">
       <i class="fas fa-file-pdf" style="font-size:1.5em;"></i>

--- a/opengov.md
+++ b/opengov.md
@@ -1,5 +1,6 @@
 ---
 title: OpenGov
+hide_footer: true
 layout: default
 breadcrumbs: true  
 toc: false
@@ -266,4 +267,7 @@ Thanks for reading!
 
 ---
 
-**[←Previous Project](smartling-workflows.md)** - **[Info →](info.md)**
+<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
+  <a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Home</a>
+  <a href="/smartling-jobs" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+</div>

--- a/smartling-jobs.md
+++ b/smartling-jobs.md
@@ -1,5 +1,6 @@
 ---
 title: Jobs Dashboard
+hide_footer: true
 layout: default
 toc: false
 toc_sticky: true
@@ -157,4 +158,7 @@ Future phases are planned to catch up the code to the UX vision where we intend 
 
 ---
 
-**[Next Project →](smartling-transcreation.md)**
+<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
+  <a href="/opengov" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
+  <a href="/smartling-workflows" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+</div>

--- a/smartling-transcreation.md
+++ b/smartling-transcreation.md
@@ -1,5 +1,6 @@
 ---
 title: Transcreation
+hide_footer: true
 layout: default
 toc: false
 toc_sticky: false
@@ -136,4 +137,7 @@ Transcreation Demo to present the new tool to our customers as well as those int
 
 ---
 
-**[←Previous Project](smartling-jobs.md)** - **[Next Project →](smartling-workflows.md)**
+<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
+  <a href="/smartling-workflows" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
+  <a href="/highlight" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+</div>

--- a/smartling-workflows.md
+++ b/smartling-workflows.md
@@ -1,5 +1,6 @@
 ---
 title: Workflows 2.0
+hide_footer: true
 layout: default
 toc: false
 toc_sticky: true
@@ -173,4 +174,7 @@ Where we landed was thanks to the help of Product, Engineering and UX collaborat
 
 ---
 
-**[←Previous Project](smartling-transcreation.md)** - **[Next Project →](opengov.md)**
+<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
+  <a href="/smartling-jobs" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
+  <a href="/smartling-transcreation" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+</div>


### PR DESCRIPTION
## Summary
- App-like page transitions: content fades out/in on navigation, nav bar slides up/down and resizes (full-size on the homepage, compact on secondary pages), background gradient fades in with a slight stagger for a layered "app boot" feel instead of a flat page-load snap
- Info page contact icons updated: Email, LinkedIn, GitHub, Résumé (Mastodon and Bluesky were added then hidden for now, pending a decision on active social use)
- All project pages get a consistent Previous/Next footer nav following the homepage tile order: OpenGov -> Jobs -> Workflows -> Transcreation -> Highlight -> Info, styled to match the existing "Back" link (muted uppercase, thin top border, left/right aligned)
- OpenGov (first in the sequence) gets a "Home" link where "Previous" would normally sit
- Fixed broken relative `.md` links in the old footer nav — browsers were resolving them against the current URL into nonexistent `/*.md` paths instead of the site's clean routes
- Added `hide_footer: true` to project pages now that they have their own nav, removing the duplicate site-wide footer

## Test plan
- [ ] Click through Home -> OpenGov -> Jobs -> Workflows -> Transcreation -> Highlight -> Info and confirm every Previous/Next/Home/Info link resolves correctly
- [ ] Watch the transition on each click: content fades, nav bar slides/resizes, background gradient fades in
- [ ] Confirm project pages no longer show the site-wide footer icons
- [ ] Info page shows 4 contact icons (Email, LinkedIn, GitHub, Résumé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)