### PR TITLE
Polish page transitions, info page copy, and add bottom accent bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .DS_Store
 vendor
 .obsidian
+CLAUDE.md

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -22,7 +22,7 @@
     e.preventDefault();
     document.body.classList.remove('page-loaded');
     document.body.classList.add('page-leaving');
-    setTimeout(function() { window.location.href = url.href; }, 220);
+    setTimeout(function() { window.location.href = url.href; }, 200);
   });
 
   window.addEventListener('pageshow', function(e) {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -12,6 +12,19 @@ search: false
 @import '../css/ibm-plex.css';
 @import '../css/ibm-plex.min.css';
 
+.page__content p, .initial-content p {
+    text-wrap: pretty;
+}
+
+body::after {
+    content: "";
+    display: block;
+    width: 100%;
+    height: 20px;
+    background: #B8963A;
+    pointer-events: none;
+}
+
 .initial-content {
     opacity: 0;
     transition: opacity 0.35s ease-out;
@@ -22,7 +35,7 @@ body.page-loaded .initial-content {
 }
 body.page-leaving .initial-content {
     opacity: 0;
-    transition-delay: 0s;
+    transition: opacity 0.18s ease-in;
 }
 
 
@@ -44,6 +57,7 @@ body.layout--front.page-loaded::before {
 }
 body.layout--front.page-leaving::before {
     opacity: 0;
+    transition: opacity 0.18s ease-in;
 }
 body.layout--front .masthead {
     position: relative;
@@ -59,6 +73,7 @@ body.page-loaded .masthead {
 }
 body.page-leaving .masthead {
     transform: translateY(-100%);
+    transition: transform 0.18s ease-in;
 }
 body:not(.layout--front) .masthead__inner-wrap {
     padding-top: 0.6em;
@@ -74,7 +89,7 @@ body.page--info::before {
     left: 0;
     width: 100%;
     height: 100vh;
-    background: linear-gradient(to bottom, rgba(100, 116, 139, 0.12), rgba(100, 116, 139, 0) 60%);
+    background: linear-gradient(to bottom, rgba(71, 85, 105, 0.24), rgba(71, 85, 105, 0) 60%);
     pointer-events: none;
     z-index: 0;
     opacity: 0;
@@ -85,6 +100,7 @@ body.page--info.page-loaded::before {
 }
 body.page--info.page-leaving::before {
     opacity: 0;
+    transition: opacity 0.18s ease-in;
 }
 body.page--info .masthead {
     position: relative;
@@ -440,7 +456,7 @@ span.project-subheader {
     width: 0px !important;
 }
 
-/* ── Intro word stagger ── */
+/* -- Intro word stagger -- */
 .word-pop {
     display: inline-block;
     opacity: 0;
@@ -450,8 +466,12 @@ span.project-subheader {
     0%   { opacity: 0; transform: translateY(12px); }
     100% { opacity: 1; transform: translateY(0); }
 }
+.fade-in-block {
+    opacity: 0;
+    animation: word-pop 0.5s ease-out forwards;
+}
 
-/* ── Project tile grid animations ── */
+/* -- Project tile grid animations -- */
 .container {
     width: 100%;
     max-width: 1280px;
@@ -549,7 +569,7 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     .css-anim * { animation: none !important; }
 }
 
-/* OG — Wayfinding */
+/* OG -- Wayfinding */
 .anim-og { width: 100%; height: 72px; display: flex; align-items: center; justify-content: center; }
 .og-row { display: flex; align-items: center; }
 .og-cell { display: flex; align-items: center; justify-content: center; flex-shrink: 0; overflow: hidden; }

--- a/info.md
+++ b/info.md
@@ -4,18 +4,29 @@ classes: page--info
 ---
 <a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
 
+<img src="../assets/img/Info-Justin-Pocta.jpg" class="fifty-right word-pop" style="animation-delay:0.5s;" alt="Justin Pocta">
+
+<div class="fade-in-block" style="animation-delay:0.45s;" markdown="1">
+
 # Hello!
 
-![Justin Pocta](../assets/img/Info-Justin-Pocta.jpg)
-{: .fifty-right}
+*I'm Justin Pocta, an NYC-based Senior Product Designer @ <a href="https://www.letshighlight.com" class="rinse-repeat-link" style="color:#B8963A;">Highlight</a>.*
 
-*I'm a Sr. Product Designer @ <a href="https://www.letshighlight.com" class="rinse-repeat-link" style="color:#B8963A;">Highlight</a>*
+</div>
+
+<div class="fade-in-block" style="animation-delay:0.65s;" markdown="1">
 
 One of my major passions is applying my design skills toward the refinement and clarity of a digital project's experience. My obsession with constantly learning more has led me, project-by-project, to being increasingly human-centered in my process and what I see as necessary for an app or website to be truly _successful_. Helping useful tools become more enjoyable and easier to understand is what I strive to do.
 
-I love working with teams that value asking questions. _Why are we creating a given project? What is the objective and our goal? How could we achieve it differently, better, smarter, faster? What if we tried it another way?_ 
+</div>
 
-<div style="border: 2px solid #D4B870; border-radius: 6px; padding: 26px 32px 32px; margin: 1.5em 0 40px; text-align: center; box-sizing: border-box; overflow: hidden;">
+<div class="fade-in-block" style="animation-delay:0.85s;" markdown="1">
+
+I love working with teams that value asking questions. _Why are we creating a given project? What is the objective and our goal? How could we achieve it differently, better, smarter, faster? What if we tried it another way?_ 
+
+</div>
+
+<div class="fade-in-block" style="animation-delay:1.05s; border: 2px solid #D4B870; border-radius: 6px; padding: 26px 32px 32px; margin: 1.5em 0 40px; text-align: center; box-sizing: border-box; overflow: hidden;">
   <p style="margin: 0 0 28px; font-weight: 400; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.1em; color: #999;">Get in Touch</p>
   <div style="display: flex; gap: 48px; justify-content: center;">
     <a href="mailto:howdy@justinpocta.com?subject=Hello" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">


### PR DESCRIPTION
## Summary
- Fixed page-transition timing mismatch: leave-state animations now use a fast, dedicated 180ms transition matching the JS navigation delay (previously waited only 220ms before navigating despite 350-500ms CSS transitions, causing old page content to visibly linger)
- Info page content (photo, headline, paragraphs, contact box) now has a proper staggered entrance, timed to start after the page wrapper's own fade-in completes
- Darkened the info page's background gradient so it's actually visible
- Fixed a Kramdown gotcha: raw HTML wrapper divs need `markdown="1"` or nested markdown syntax renders as literal text
- Info page tagline updated to introduce name + NYC location
- Added `text-wrap: pretty` to body paragraphs to reduce orphans
- Added a 20px gold accent bar visible at the true bottom of every page

## Test plan
- [ ] Click between pages and confirm no lingering/ghost content mid-transition
- [ ] Visit `/info` via a click-navigation and watch the staggered entrance (photo, heading, paragraphs, contact box)
- [ ] Confirm `/info` markdown (headings, italics, links) all render correctly, not as literal text
- [ ] Scroll to the bottom of any page and confirm the gold bar appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)