### PR TITLE
Fix: add missing social widget includes for hi page

### DIFF
--- a/_includes/bluesky.html
+++ b/_includes/bluesky.html
@@ -1,0 +1,186 @@
+<!--
+  Bluesky "Latest Post" widget
+  ----------------------------
+  Public, unauthenticated read -- no API key needed.
+-->
+
+<div id="bsky-widget" class="social-widget">
+  <p class="social-loading">Loading latest post&hellip;</p>
+</div>
+
+<style>
+  .social-widget {
+    max-width: 500px;
+    margin: 1.5rem 0;
+    font-family: inherit;
+  }
+  .social-post {
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    background: #fff;
+    padding: 14px 16px;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    position: relative;
+  }
+  .social-post:hover { border-color: #999; }
+  .social-post-text { margin: 0 0 8px; line-height: 1.4; }
+  .social-post-meta { font-size: 0.85rem; color: #888; }
+  .social-loading { color: #888; font-size: 0.9rem; }
+  .bsky-card {
+    margin-bottom: 28px;
+  }
+  .bsky-card:last-child {
+    margin-bottom: 0;
+  }
+  .bsky-tail {
+    position: absolute;
+    bottom: -7px;
+    left: 28px;
+    width: 14px;
+    height: 14px;
+    background: #fff;
+    border-right: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+    border-bottom-right-radius: 3px;
+    transform: rotate(45deg);
+  }
+  .bsky-bubble:hover .bsky-tail {
+    border-color: #999;
+  }
+  .bsky-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 18px;
+    padding-left: 4px;
+  }
+  .bsky-icon-svg {
+    flex: 0 0 auto;
+    display: block;
+  }
+  .bsky-handle {
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+  .bsky-dot {
+    color: #999;
+  }
+  .bsky-date {
+    color: #888;
+    font-size: 0.9rem;
+  }
+  .social-media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    gap: 4px;
+    margin: 0 0 8px;
+  }
+  .social-media-item {
+    position: relative;
+    border-radius: 6px;
+    overflow: hidden;
+    aspect-ratio: 1 / 1;
+  }
+  .social-media-item.social-media-video {
+    aspect-ratio: 16 / 9;
+  }
+  .social-media-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .social-media-badge {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    font-size: 0.7rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+</style>
+
+<script>
+(function () {
+  var BSKY_HANDLE = "justinpnyc.bsky.social";
+  var POST_COUNT  = 1;
+
+  var url = "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed"
+    + "?actor=" + encodeURIComponent(BSKY_HANDLE)
+    + "&filter=posts_no_replies"
+    + "&limit=" + POST_COUNT;
+
+  function escapeHtml(str) {
+    return (str || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  function renderMedia(embed) {
+    if (!embed) return "";
+
+    if (embed.$type === "app.bsky.embed.images#view" && embed.images && embed.images.length) {
+      var imgs = embed.images.map(function (img) {
+        return '<div class="social-media-item"><img class="social-media-thumb" src="' + img.thumb + '" alt="' + escapeHtml(img.alt) + '"></div>';
+      }).join("");
+      return '<div class="social-media-grid">' + imgs + '</div>';
+    }
+
+    if (embed.$type === "app.bsky.embed.video#view" && embed.thumbnail) {
+      return '<div class="social-media-grid"><div class="social-media-item social-media-video">' +
+        '<img class="social-media-thumb" src="' + embed.thumbnail + '" alt="Video thumbnail">' +
+        '<span class="social-media-badge">&#9654; Video</span>' +
+        '</div></div>';
+    }
+
+    return "";
+  }
+
+  function bskyIcon() {
+    return '<svg class="bsky-icon-svg" fill="none" viewBox="0 0 64 57" width="20" height="18" xmlns="http://www.w3.org/2000/svg">' +
+      '<path fill="#0F73FF" d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805ZM50.127 3.805C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745Z"/>' +
+      "</svg>";
+  }
+
+  function renderPost(item) {
+    var post = item.post;
+    var text = post.record.text || "";
+    var date = new Date(post.record.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    var postId = post.uri.split("/").pop();
+    var link = "https://bsky.app/profile/" + BSKY_HANDLE + "/post/" + postId;
+
+    return '<div class="bsky-card">' +
+      '<a class="social-post bsky-bubble" href="' + link + '" target="_blank" rel="noopener">' +
+        renderMedia(post.embed) +
+        '<p class="social-post-text">' + escapeHtml(text) + "</p>" +
+        '<span class="bsky-tail"></span>' +
+      "</a>" +
+      '<div class="bsky-footer">' +
+        bskyIcon() +
+        '<span class="bsky-handle">@' + escapeHtml(BSKY_HANDLE) + "</span>" +
+        '<span class="bsky-dot">&middot;</span>' +
+        '<span class="bsky-date">' + date + "</span>" +
+      "</div>" +
+    "</div>";
+  }
+
+  fetch(url)
+    .then(function (res) { return res.json(); })
+    .then(function (data) {
+      var container = document.getElementById("bsky-widget");
+      var items = data.feed || [];
+
+      if (!items.length) {
+        container.innerHTML = "<p>No recent posts.</p>";
+        return;
+      }
+
+      container.innerHTML = items.map(renderPost).join("");
+    })
+    .catch(function () {
+      document.getElementById("bsky-widget").innerHTML = "<p>Couldn't load post.</p>";
+    });
+})();
+</script>

--- a/_includes/flickr.html
+++ b/_includes/flickr.html
@@ -1,0 +1,131 @@
+<!--
+  Flickr Recent Photos Widget
+  ---------------------------
+  Uses Flickr's public JSONP endpoint -- no server/proxy needed, no API secret
+  required (that's only for signed/write calls, which this isn't).
+-->
+
+<div id="flickr-widget" class="flickr-widget">
+  <p class="flickr-loading">Loading photos&hellip;</p>
+</div>
+
+<style>
+  .flickr-widget {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    box-sizing: border-box;
+    gap: 8px;
+    /* break out of the page's centered max-width container to span the full viewport */
+    width: 100vw;
+    margin: 1.5rem calc(50% - 50vw);
+    padding: 0 24px;
+    cursor: grab;
+    scrollbar-width: none;
+  }
+  .flickr-widget::-webkit-scrollbar {
+    display: none;
+  }
+  .flickr-widget.dragging {
+    cursor: grabbing;
+  }
+  .flickr-widget a {
+    display: block;
+    overflow: hidden;
+    border-radius: 6px;
+    aspect-ratio: 1 / 1;
+    flex: 0 0 auto;
+    width: 240px;
+    scroll-snap-align: center;
+  }
+  .flickr-widget img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.25s ease;
+  }
+  .flickr-widget a:hover img {
+    transform: scale(1.05);
+  }
+  .flickr-loading {
+    color: #888;
+    font-size: 0.9rem;
+  }
+</style>
+
+<script>
+(function () {
+  var FLICKR_API_KEY = "10603b12c8391b253b19e8f4e01a42b8";
+  var FLICKR_USER_ID  = "59585990@N00";
+  var PHOTO_COUNT     = 12;
+
+  window.jsonFlickrApi = function (data) {
+    var container = document.getElementById("flickr-widget");
+    container.innerHTML = "";
+
+    if (data.stat !== "ok") {
+      container.innerHTML = "<p>Couldn't load photos right now.</p>";
+      return;
+    }
+
+    data.photos.photo.forEach(function (p) {
+      var thumbUrl = "https://live.staticflickr.com/" + p.server + "/" + p.id + "_" + p.secret + "_c.jpg";
+      var pageUrl  = "https://www.flickr.com/photos/" + FLICKR_USER_ID + "/" + p.id;
+
+      var link = document.createElement("a");
+      link.href = pageUrl;
+      link.target = "_blank";
+      link.rel = "noopener";
+
+      var img = document.createElement("img");
+      img.src = thumbUrl;
+      img.alt = p.title || "Flickr photo";
+      img.loading = "lazy";
+
+      link.appendChild(img);
+      container.appendChild(link);
+    });
+  };
+
+  var script = document.createElement("script");
+  script.src = "https://api.flickr.com/services/rest/?method=flickr.people.getPublicPhotos"
+    + "&api_key=" + FLICKR_API_KEY
+    + "&user_id=" + FLICKR_USER_ID
+    + "&per_page=" + PHOTO_COUNT
+    + "&format=json"
+    + "&jsoncallback=jsonFlickrApi";
+  document.body.appendChild(script);
+
+  var row = document.getElementById("flickr-widget");
+  var isDown = false, startX, scrollLeft, moved;
+
+  row.addEventListener("mousedown", function (e) {
+    isDown = true;
+    moved = false;
+    row.classList.add("dragging");
+    startX = e.pageX - row.offsetLeft;
+    scrollLeft = row.scrollLeft;
+  });
+  window.addEventListener("mouseup", function () {
+    isDown = false;
+    row.classList.remove("dragging");
+  });
+  row.addEventListener("mousemove", function (e) {
+    if (!isDown) return;
+    e.preventDefault();
+    var x = e.pageX - row.offsetLeft;
+    var walk = x - startX;
+    if (Math.abs(walk) > 5) moved = true;
+    row.scrollLeft = scrollLeft - walk;
+  });
+  row.addEventListener("click", function (e) {
+    if (moved) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, true);
+})();
+</script>

--- a/_includes/mastodon.html
+++ b/_includes/mastodon.html
@@ -1,0 +1,172 @@
+<!--
+  Mastodon "Latest Post" widget
+  -----------------------------
+  Public, unauthenticated read -- no API key needed.
+-->
+
+<div id="mastodon-widget" class="social-widget">
+  <p class="social-loading">Loading latest post&hellip;</p>
+</div>
+
+<style>
+  .social-widget {
+    max-width: 500px;
+    margin: 1.5rem 0;
+    font-family: inherit;
+  }
+  .social-post {
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    background: #fff;
+    padding: 14px 16px;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    position: relative;
+  }
+  .social-post:hover { border-color: #999; }
+  .social-post-text { margin: 0 0 8px; line-height: 1.4; }
+  .social-post-meta { font-size: 0.85rem; color: #888; }
+  .social-loading { color: #888; font-size: 0.9rem; }
+  .mastodon-card {
+    margin-bottom: 28px;
+  }
+  .mastodon-card:last-child {
+    margin-bottom: 0;
+  }
+  .mastodon-tail {
+    position: absolute;
+    bottom: -7px;
+    left: 28px;
+    width: 14px;
+    height: 14px;
+    background: #fff;
+    border-right: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+    border-bottom-right-radius: 3px;
+    transform: rotate(45deg);
+  }
+  .mastodon-bubble:hover .mastodon-tail {
+    border-color: #999;
+  }
+  .mastodon-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 18px;
+    padding-left: 4px;
+  }
+  .mastodon-icon-svg {
+    flex: 0 0 auto;
+    display: block;
+  }
+  .mastodon-handle {
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+  .mastodon-dot {
+    color: #999;
+  }
+  .mastodon-date {
+    color: #888;
+    font-size: 0.9rem;
+  }
+  .social-media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    gap: 4px;
+    margin: 0 0 8px;
+  }
+  .social-media-item {
+    position: relative;
+    border-radius: 6px;
+    overflow: hidden;
+    aspect-ratio: 1 / 1;
+  }
+  .social-media-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .social-media-badge {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    font-size: 0.7rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+</style>
+
+<script>
+(function () {
+  var MASTODON_INSTANCE = "mastodon.social";
+  var MASTODON_USER_ID   = "110180914791282620"; // verified against @justinpocta via mastodon.social API
+  var POST_COUNT         = 1;
+
+  var url = "https://" + MASTODON_INSTANCE + "/api/v1/accounts/" + MASTODON_USER_ID
+    + "/statuses?exclude_replies=true&exclude_reblogs=true&limit=" + POST_COUNT;
+
+  function escapeHtml(str) {
+    return (str || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  function renderMedia(attachments) {
+    if (!attachments || !attachments.length) return "";
+
+    var thumbs = attachments.map(function (m) {
+      var isVideo = m.type === "video" || m.type === "gifv";
+      var badge = isVideo ? '<span class="social-media-badge">&#9654; Video</span>' : "";
+      return '<div class="social-media-item"><img class="social-media-thumb" src="' + m.preview_url + '" alt="' + escapeHtml(m.description) + '">' + badge + '</div>';
+    }).join("");
+
+    return '<div class="social-media-grid">' + thumbs + '</div>';
+  }
+
+  function mastodonIcon(gradientId) {
+    return '<svg class="mastodon-icon-svg" width="20" height="20" viewBox="0 0 61 65" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+      '<path d="M60.7539 14.3904C59.8143 7.40642 53.7273 1.90257 46.5117 0.836066C45.2943 0.655854 40.6819 0 29.9973 0H29.9175C19.2299 0 16.937 0.655854 15.7196 0.836066C8.70488 1.87302 2.29885 6.81852 0.744617 13.8852C-0.00294988 17.3654 -0.0827298 21.2237 0.0561464 24.7629C0.254119 29.8384 0.292531 34.905 0.753482 39.9598C1.07215 43.3175 1.62806 46.6484 2.41704 49.9276C3.89445 55.9839 9.87499 61.0239 15.7344 63.0801C22.0077 65.2244 28.7542 65.5804 35.2184 64.1082C35.9295 63.9428 36.6318 63.7508 37.3252 63.5321C38.8971 63.0329 40.738 62.4745 42.0913 61.4937C42.1099 61.4799 42.1251 61.4621 42.1358 61.4417C42.1466 61.4212 42.1526 61.3986 42.1534 61.3755V56.4773C42.153 56.4557 42.1479 56.4345 42.1383 56.4151C42.1287 56.3958 42.1149 56.3788 42.0979 56.3655C42.0809 56.3522 42.0611 56.3429 42.04 56.3382C42.019 56.3335 41.9971 56.3336 41.9761 56.3384C37.8345 57.3276 33.5905 57.8234 29.3324 57.8156C22.0045 57.8156 20.0336 54.3384 19.4693 52.8908C19.0156 51.6397 18.7275 50.3346 18.6124 49.0088C18.6112 48.9866 18.6153 48.9643 18.6243 48.9439C18.6333 48.9236 18.647 48.9056 18.6643 48.8915C18.6816 48.8774 18.7019 48.8675 18.7237 48.8628C18.7455 48.858 18.7681 48.8585 18.7897 48.8641C22.8622 49.8465 27.037 50.3423 31.2265 50.3412C32.234 50.3412 33.2387 50.3412 34.2463 50.3146C38.4598 50.1964 42.9009 49.9808 47.0465 49.1713C47.1499 49.1506 47.2534 49.1329 47.342 49.1063C53.881 47.8507 60.1038 43.9097 60.7362 33.9301C60.7598 33.5372 60.8189 29.8148 60.8189 29.4071C60.8218 28.0215 61.2651 19.5781 60.7539 14.3904Z" fill="url(#' + gradientId + ')"/>' +
+      '<path d="M50.3943 22.237V39.5876H43.5185V22.7481C43.5185 19.2029 42.0411 17.3949 39.036 17.3949C35.7325 17.3949 34.0778 19.5338 34.0778 23.7585V32.9759H27.2434V23.7585C27.2434 19.5338 25.5857 17.3949 22.2822 17.3949C19.2949 17.3949 17.8027 19.2029 17.8027 22.7481V39.5876H10.9298V22.237C10.9298 18.6918 11.835 15.8754 13.6453 13.7877C15.5128 11.7049 17.9623 10.6355 21.0028 10.6355C24.522 10.6355 27.1813 11.9885 28.9542 14.6917L30.665 17.5633L32.3788 14.6917C34.1517 11.9885 36.811 10.6355 40.3243 10.6355C43.3619 10.6355 45.8114 11.7049 47.6847 13.7877C49.4931 15.8734 50.3963 18.6899 50.3943 22.237Z" fill="white"/>' +
+      '<defs><linearGradient id="' + gradientId + '" x1="30.5" y1="0" x2="30.5" y2="65" gradientUnits="userSpaceOnUse"><stop stop-color="#6364FF"/><stop offset="1" stop-color="#563ACC"/></linearGradient></defs>' +
+      "</svg>";
+  }
+
+  function renderPost(post, index) {
+    var date = new Date(post.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    var handle = "@" + (post.account && post.account.username ? post.account.username : "justinpocta");
+
+    return '<div class="mastodon-card">' +
+      '<a class="social-post mastodon-bubble" href="' + post.url + '" target="_blank" rel="noopener">' +
+        renderMedia(post.media_attachments) +
+        '<div class="social-post-text">' + post.content + "</div>" +
+        '<span class="mastodon-tail"></span>' +
+      "</a>" +
+      '<div class="mastodon-footer">' +
+        mastodonIcon("mastodon-grad-" + index) +
+        '<span class="mastodon-handle">' + escapeHtml(handle) + "</span>" +
+        '<span class="mastodon-dot">&middot;</span>' +
+        '<span class="mastodon-date">' + date + "</span>" +
+      "</div>" +
+    "</div>";
+  }
+
+  fetch(url)
+    .then(function (res) { return res.json(); })
+    .then(function (data) {
+      var container = document.getElementById("mastodon-widget");
+
+      if (!data.length) {
+        container.innerHTML = "<p>No recent posts.</p>";
+        return;
+      }
+
+      container.innerHTML = data.map(renderPost).join("");
+    })
+    .catch(function () {
+      document.getElementById("mastodon-widget").innerHTML = "<p>Couldn't load post.</p>";
+    });
+})();
+</script>


### PR DESCRIPTION
Adds the three `_includes` files that `hi.md` references but were never committed, causing the GitHub Pages build to fail.

- `_includes/flickr.html` — Flickr recent photos widget
- `_includes/bluesky.html` — Bluesky latest post widget
- `_includes/mastodon.html` — Mastodon latest post widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)