### PR TITLE
Polish: Rinse & Repeat contrast, mobile bg, Info tile label (#20)

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -178,8 +178,8 @@
     <div class="tile-label">
       <div class="project-title-container">
         <div class="tile-text">
-          <div class="tile-company" style="color:rgba(0,0,0,0.45);">Info</div>
-          <div class="project-title-name" style="color:rgba(0,0,0,0.75);">Justin Pocta</div>
+          <div class="tile-company" style="color:rgba(255,255,255,0.65);">Info</div>
+          <div class="project-title-name" style="color:rgba(255,255,255,0.9);">Justin Pocta</div>
         </div>
       </div>
     </div>
@@ -361,7 +361,7 @@
           tile.removeAttribute('href');
         }
       });
-      if (window.matchMedia('(hover: hover)').matches) _applyTileBg(tiles[idx]);
+      _applyTileBg(tiles[idx]);
     }
 
     btnLeft.addEventListener('click', function() {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -397,6 +397,7 @@ body.bg-dark .masthead__menu-item a:hover {
 }
 .rinse-repeat-link {
     text-decoration: none;
+    font-weight: 500;
     background-image: linear-gradient(#B8963A, #B8963A);
     background-position: 0 100%;
     background-repeat: no-repeat;
@@ -422,8 +423,8 @@ body.bg-dark .masthead__menu-item a:hover {
 }
 /* -- Front page: gold by default, muted on tile hover -- */
 body.layout--front .rinse-repeat-link {
-    color: white;
-    background-image: linear-gradient(white, white);
+    color: #000;
+    background-image: linear-gradient(#000, #000);
     transition: background-size 0.35s ease;
 }
 body.layout--front .masthead__menu-item a[href="/info"]:before {


### PR DESCRIPTION
## Summary
- Rinse & Repeat link: black color + `font-weight: 500` for legibility against warm backgrounds
- Mobile: body background now updates when scrolling between tiles (removed desktop-only gate)
- Info tile label: white text so "Justin Pocta" is readable over the photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)