### PR TITLE
Remove duplicate Project Notes from case study pages

### DIFF
--- a/opengov.md
+++ b/opengov.md
@@ -260,45 +260,6 @@ Explorations where I aimed to reduce the user journey by creating more guidance 
 
 Thanks for reading!
 
-***
-
-# Project Notes
-
-## Details
-
-<span class="project-subheader">Website</span>
-- [http://opengov.com](http://opengov.com)
-
-<span class="project-subheader">Timeline</span>
-- 2021 Q3-Q4
-
----
-
-## The Team
-
-<span class="project-subheader">Product/Design</span>
-- Richard Baker (VP of UX)
-- Justin Pocta (UX/UI)
-- Lalitha Balasubramhanya (Sr. Director of Product Management)
-- Christine Liu (Product Manager)
-- Kim Henry (Lead UX Researcher)
-
-<span class="project-subheader">Development</span>
-- Dale (FE Lead of App Frame)
-- Wei Huang (Sr. Engineering Manager)
-- Honestly, *most* of the engineering team helped fill in a lot of information and gave great guidance who weren’t necessarily on the projects I was designing. 
-
-<span class="project-subheader">Tools</span>
-- Pendo.io for Data Analytics/Dashboard of Reports, creating In-App Walk-thru Guides for users, and generating messages to collect Feedback and Survey Data
-- ProductBoard/Trello for Project Management + JIRA and Confluence
-- Google Slides for presentations
-- Figma for Design and Prototyping
-- Miro for Workshop Whiteboards
-- Loom for sharing updates async
-- Zoom and Figma for User Interviews and Usability Tests
-
----
-
 <div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
   <a href="/highlight-recruiting" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
   <a href="/smartling-jobs" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>

--- a/smartling-jobs.md
+++ b/smartling-jobs.md
@@ -162,32 +162,6 @@ Future phases are planned to catch up the code to the UX vision where we intend 
 
 {% include gallery layout="" id="galleryFinal" caption="" %}
 
-***
-
-# Project Notes
-
-## Details
-
-<span class="project-subheader">WEBSITE</span>
-- [http://smartling.com](http://smartling.com/)
-
-<span class="project-subheader">Timeline</span>
-- *DISCOVERY TO DEV HANDOFF*
-- Jan 2020—August 2020
-
----
-
-## The Team
-
-<span class="project-subheader">Product/Design</span>
-- Sophia Lazare (PM)
-- Justin Pocta (UX/UI)
-
-<span class="project-subheader">Development</span>
-- Jeremy Shankle, Dmitry Masley, Oleksandr Tymchenko, Pavlo Myrotiuk, Valerii Linetskyi, Sergey Chichulin, Yurii Beiko, Xiaoyun Yang, Rich Tam, and our summer intern Dominic DeMarco alongside multiple BE teams to get all the pieces converged and working smoothly.
-
----
-
 <div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
   <a href="/opengov" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
   <a href="/smartling-workflows" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>

--- a/smartling-transcreation.md
+++ b/smartling-transcreation.md
@@ -140,33 +140,6 @@ Transcreation Demo to present the new tool to our customers as well as those int
 - Article: [Automating Transcreation](https://www.linkedin.com/pulse/automating-transcreation-joseph-kovalov/?trackingId=BSoligoMdVW7DjQ%2BobyuSg%3D%3D)
   
 
----
-
-# Project Notes
-
-## Details
-
-<span class="project-subheader">Website</span>
-- [http://smartling.com](http://smartling.com/)
-
-<span class="project-subheader">Timeline</span>
-- *DISCOVERY TO DEV HANDOFF*
-- Jan 2020—July 2020
-
----
-
-## The Team
-
-<span class="project-subheader">Product/Design</span>
-- Sophia Lazare (PM), Tobias Kahn (PM)
-- Justin Pocta (UX/UI), [Frannie Laks](http://frannielaks.com) (UX/UI)
-
-<span class="project-subheader">Development</span>
-- Anton Shanyuk (FE Engineer)
-- Keith Legin (Engineer Lead)
-
----
-
 <div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
   <a href="/smartling-workflows" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
   <a href="/info" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>

--- a/smartling-workflows.md
+++ b/smartling-workflows.md
@@ -176,34 +176,6 @@ Where we landed was thanks to the help of Product, Engineering and UX collaborat
 ### Managing Rules for Decision Steps
 <iframe src="https://www.youtube.com/embed/sB9zdrpP3j8?controls=0" title="YouTube video player"  class="youtube-handler" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
----
-
-# Project Notes
-
-## Details
-
-<span class="project-subheader">Website</span>
-- [http://smartling.com](http://smartling.com/)
-
-<span class="project-subheader">Timeline</span>
-- *Kickoff to Dev Handoff*
-- Jan 2019—Apr 2019
-
----
-## The Team
-
-<span class="project-subheader">Product/Design</span>
-- Franco Parico (PM)
-- Justin Pocta (UX/UI)
-
-<span class="project-subheader">Development</span>
-- Xiaoyun Yang (FE - MVP)
-- Oleksandr Tymchenko (FE - 1.0+)
-- Ben Loy (BE)
-- Dmitry Bochorishvili (BE)
-
----
-
 <div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
   <a href="/smartling-jobs" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
   <a href="/smartling-transcreation" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>


### PR DESCRIPTION
## Summary

Removes the old \"Project Notes\" sections (Website, Timeline, The Team) from the bottom of all 4 Smartling/OpenGov case study pages. This info now lives in the `case-meta` blocks at the top of each page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)