### PR TITLE
OpenGov sidebar intro layout

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -5,7 +5,7 @@
 <div class="container scroll-test" id="tile-scroll-row">
 
   <!-- Highlight / Recruiting -->
-  <a href="/highlight-recruiting" class="video-container is-active" style="background-color:#003D2F;">
+  <a href="/highlight-recruiting" class="hero-tile is-active" style="background-color:#003D2F;">
     <div class="css-anim">
       <svg id="rec-grid" viewBox="0 0 280 280" width="280" height="280" style="max-width:100%; overflow:hidden;"></svg>
     </div>
@@ -23,7 +23,7 @@
   </a>
 
   <!-- OG / Wayfinding -->
-  <a href="/opengov" style="background-color:#E8EFF5;" class="video-container">
+  <a href="/opengov" style="background-color:#E8EFF5;" class="hero-tile">
     <div class="css-anim">
       <div class="anim-og">
         <div class="og-row">
@@ -51,7 +51,7 @@
   </a>
 
   <!-- Jobs -->
-  <a href="/smartling-jobs" style="background-color:#321261;" class="video-container">
+  <a href="/smartling-jobs" style="background-color:#321261;" class="hero-tile">
     <div class="css-anim">
       <div class="anim-jobs">
         <div class="jobs-card">
@@ -100,7 +100,7 @@
   </a>
 
   <!-- Workflows -->
-  <a href="/smartling-workflows" style="background-color:#9F29B7;" class="video-container">
+  <a href="/smartling-workflows" style="background-color:#9F29B7;" class="hero-tile">
     <div class="css-anim">
       <svg viewBox="0 0 240 140" width="220" height="128" aria-hidden="true">
         <circle cx="22" cy="70" r="9" fill="white"/>
@@ -144,7 +144,7 @@
   </a>
 
   <!-- Transcreation -->
-  <a href="/smartling-transcreation" style="background-color:#E17463;" class="video-container">
+  <a href="/smartling-transcreation" style="background-color:#E17463;" class="hero-tile">
     <div class="css-anim">
       <div class="anim-tc">
         <div class="tc-source"></div>
@@ -172,7 +172,7 @@
   </a>
 
   <!-- Highlight / Community App -->
-  <div class="video-container" style="background-color:#0F0F0F;">
+  <div class="hero-tile" style="background-color:#0F0F0F;">
     <div class="css-anim">
       <img src="/assets/img/highlight-logo.svg" class="hl-spin" alt="Highlight logo">
     </div>
@@ -193,7 +193,7 @@
   </div>
 
   <!-- Info / About -->
-  <a href="/info" style="background-color:rgb(215,197,155);" class="video-container">
+  <a href="/info" style="background-color:rgb(215,197,155);" class="hero-tile">
     <img src="/assets/img/profile-paris-03.jpg" class="info-photo" alt="">
     <div class="css-anim"></div>
     <div class="tile-label">
@@ -247,14 +247,14 @@
   }
 
   function _applyActiveTileBg() {
-    var active = document.querySelector('.video-container.is-active');
+    var active = document.querySelector('.hero-tile.is-active');
     if (active) _applyTileBg(active);
   }
 
   // ── IntersectionObserver for mobile greyscale reveal ─────────────
   (function() {
     if (!window.matchMedia('(hover: none)').matches) return;
-    var tiles = document.querySelectorAll('.video-container');
+    var tiles = document.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
         entry.target.classList.toggle('in-view', entry.isIntersecting);
@@ -269,20 +269,46 @@
     if (!row) return;
     var isDown = false, startX, scrollLeft, moved;
 
+    row.addEventListener('mouseenter', function() {
+      if (window._setCursorLock) window._setCursorLock('grab');
+    });
+    row.addEventListener('mouseleave', function() {
+      if (!isDown && window._setCursorLock) window._setCursorLock(null);
+    });
     row.addEventListener('mousedown', function(e) {
       isDown = true; moved = false;
       row.classList.add('dragging');
-      startX = e.pageX - row.offsetLeft;
+      row.style.scrollSnapType = 'none';
+      startX = e.pageX;
       scrollLeft = row.scrollLeft;
+      e.preventDefault();
     });
     window.addEventListener('mouseup', function() {
-      isDown = false; row.classList.remove('dragging');
-    });
-    row.addEventListener('mousemove', function(e) {
       if (!isDown) return;
-      e.preventDefault();
-      var walk = (e.pageX - row.offsetLeft) - startX;
-      if (Math.abs(walk) > 5) moved = true;
+      isDown = false;
+      row.classList.remove('dragging');
+      if (window._setCursorLock) window._setCursorLock(null);
+      if (moved) {
+        var tiles = Array.from(row.querySelectorAll('.hero-tile'));
+        var center = row.scrollLeft + row.clientWidth / 2;
+        var nearest = null, minDist = Infinity;
+        tiles.forEach(function(tile) {
+          var dist = Math.abs((tile.offsetLeft + tile.offsetWidth / 2) - center);
+          if (dist < minDist) { minDist = dist; nearest = tile; }
+        });
+        if (nearest) nearest.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+        setTimeout(function() { row.style.scrollSnapType = ''; }, 600);
+      } else {
+        row.style.scrollSnapType = '';
+      }
+    });
+    document.addEventListener('mousemove', function(e) {
+      if (!isDown) return;
+      var walk = e.pageX - startX;
+      if (Math.abs(walk) > 5) {
+        moved = true;
+        if (window._setCursorLock) window._setCursorLock('grabbing');
+      }
       row.scrollLeft = scrollLeft - walk;
     });
     row.addEventListener('click', function(e) {
@@ -293,33 +319,49 @@
   // ── Hover shadow ─────────────────────────────────────────────────
   (function() {
     if (!window.matchMedia('(hover: hover)').matches) return;
-    var tiles = document.querySelectorAll('.video-container');
+    var tiles = document.querySelectorAll('.hero-tile');
     var shadowEl = document.createElement('div');
     shadowEl.className = 'tile-hover-shadow';
-    shadowEl.style.cssText = 'position:fixed;pointer-events:none;border-radius:12px;z-index:9;opacity:0;transition:opacity 0.3s ease;box-shadow:0px 12px 65px rgba(0,0,0,0.32);';
+    shadowEl.style.cssText = 'position:fixed;pointer-events:none;border-radius:12px;z-index:9;opacity:0;transition:opacity 0.25s ease;box-shadow:0px 12px 65px rgba(0,0,0,0.32);';
     document.body.appendChild(shadowEl);
     var activeTile = null;
+    var rafId = null;
 
-    function syncShadow() {
+    function syncLoop() {
       if (!activeTile) return;
       var r = activeTile.getBoundingClientRect();
-      shadowEl.style.left = r.left + 'px'; shadowEl.style.top = r.top + 'px';
-      shadowEl.style.width = r.width + 'px'; shadowEl.style.height = r.height + 'px';
+      shadowEl.style.left   = r.left   + 'px';
+      shadowEl.style.top    = r.top    + 'px';
+      shadowEl.style.width  = r.width  + 'px';
+      shadowEl.style.height = r.height + 'px';
+      rafId = requestAnimationFrame(syncLoop);
     }
+
+    function stopSync() {
+      if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    }
+
     var row = document.getElementById('tile-scroll-row');
     if (row) row.addEventListener('scroll', function() {
       activeTile = null;
+      stopSync();
       shadowEl.style.opacity = '0';
     });
 
     tiles.forEach(function(tile) {
       tile.addEventListener('mouseenter', function() {
-        activeTile = tile; tile.style.zIndex = '10';
-        syncShadow(); shadowEl.style.opacity = '1';
+        if (tile.classList.contains('is-active')) return;
+        activeTile = tile;
+        tile.style.zIndex = '10';
+        shadowEl.style.opacity = '1';
+        stopSync();
+        rafId = requestAnimationFrame(syncLoop);
       });
       tile.addEventListener('mouseleave', function() {
-        activeTile = null; tile.style.zIndex = '';
+        activeTile = null;
+        tile.style.zIndex = '';
         shadowEl.style.opacity = '0';
+        stopSync();
       });
     });
   })();
@@ -327,10 +369,12 @@
   // ── Background + link color on hover, reverts to active tile ─────
   (function() {
     if (!window.matchMedia('(hover: hover)').matches) return;
-    var tiles = document.querySelectorAll('.video-container');
+    var tiles = document.querySelectorAll('.hero-tile');
 
     tiles.forEach(function(tile) {
-      tile.addEventListener('mouseenter', function() { _applyTileBg(tile); });
+      tile.addEventListener('mouseenter', function() {
+        if (!tile.classList.contains('is-active')) _applyTileBg(tile);
+      });
       tile.addEventListener('mouseleave', function(e) {
         if (e.relatedTarget && e.relatedTarget.closest && e.relatedTarget.closest('.tile-scroll-arrow')) return;
         _applyActiveTileBg();
@@ -339,7 +383,7 @@
 
     document.querySelectorAll('.tile-scroll-arrow').forEach(function(btn) {
       btn.addEventListener('mouseleave', function(e) {
-        if (e.relatedTarget && e.relatedTarget.closest && e.relatedTarget.closest('.video-container')) return;
+        if (e.relatedTarget && e.relatedTarget.closest && e.relatedTarget.closest('.hero-tile')) return;
         _applyActiveTileBg();
       });
     });
@@ -349,7 +393,7 @@
   (function() {
     var row = document.getElementById('tile-scroll-row');
     if (!row) return;
-    var tiles = Array.from(document.querySelectorAll('.video-container'));
+    var tiles = Array.from(document.querySelectorAll('.hero-tile'));
     var btnLeft = document.querySelector('.tile-scroll-arrow--left');
     var btnRight = document.querySelector('.tile-scroll-arrow--right');
     if (!btnLeft || !btnRight || tiles.length === 0) return;
@@ -376,10 +420,21 @@
       tiles.forEach(function(tile, i) {
         var active = i === idx;
         tile.classList.toggle('is-active', active);
-        if (tile.dataset.href) tile.setAttribute('href', tile.dataset.href);
+        if (tile.dataset.href) {
+          if (active) tile.setAttribute('href', tile.dataset.href);
+          else tile.removeAttribute('href');
+        }
       });
       _applyTileBg(tiles[idx]);
     }
+
+    tiles.forEach(function(tile) {
+      tile.addEventListener('click', function() {
+        if (!tile.classList.contains('is-active')) {
+          tile.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+        }
+      });
+    });
 
     btnLeft.addEventListener('click', function() {
       var idx = getCurrentIndex();

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -13,6 +13,7 @@
 
     var href = a.getAttribute('href');
     if (!href || href.charAt(0) === '#' || href.indexOf('mailto:') === 0 || href.indexOf('tel:') === 0) return;
+    if (/\.(jpg|jpeg|png|gif|webp|svg)$/i.test(href)) return;
 
     var url;
     try { url = new URL(href, window.location.href); } catch (err) { return; }
@@ -28,6 +29,80 @@
   window.addEventListener('pageshow', function(e) {
     document.body.classList.remove('page-leaving');
     document.body.classList.add('page-loaded');
+  });
+
+  // Shared cursor lock — injects/updates a <style> to override ALL cursor rules,
+  // bypassing pointer-events boundaries and animated child elements.
+  window._cursorLockEl = null;
+  window._setCursorLock = function(cursor) {
+    if (!window._cursorLockEl) {
+      window._cursorLockEl = document.createElement('style');
+      document.head.appendChild(window._cursorLockEl);
+    }
+    window._cursorLockEl.textContent = cursor
+      ? 'html, html * { cursor: ' + cursor + ' !important; }'
+      : '';
+  };
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var sel = '.project-section figure.half, .project-section figure.third, .project-section figure.quarter';
+    document.querySelectorAll(sel).forEach(function(carousel) {
+      var isDown = false, hasDragged = false, startX = 0, scrollLeft = 0;
+
+      function updateEdgeFade() {
+        var items = carousel.querySelectorAll('a');
+        if (items.length === 0) return;
+        var cr = carousel.getBoundingClientRect();
+        var firstLeft = items[0].getBoundingClientRect().left;
+        var lastRight = items[items.length - 1].getBoundingClientRect().right;
+        carousel.classList.toggle('scroll-at-start', firstLeft >= cr.left - 4);
+        carousel.classList.toggle('scroll-at-end',   lastRight <= cr.right + 4);
+      }
+      carousel.addEventListener('scroll', updateEdgeFade);
+      // Double rAF so snap has settled before the initial check
+      requestAnimationFrame(function() { requestAnimationFrame(updateEdgeFade); });
+
+      carousel.addEventListener('mouseenter', function() {
+        window._setCursorLock('grab');
+      });
+      carousel.addEventListener('mouseleave', function() {
+        if (!isDown) window._setCursorLock(null);
+      });
+
+      carousel.addEventListener('mousedown', function(e) {
+        isDown = true;
+        hasDragged = false;
+        startX = e.pageX;
+        scrollLeft = carousel.scrollLeft;
+        e.preventDefault();
+      });
+
+      document.addEventListener('mouseup', function() {
+        if (!isDown) return;
+        isDown = false;
+        carousel.classList.remove('is-dragging');
+        window._setCursorLock(null);
+      });
+
+      document.addEventListener('mousemove', function(e) {
+        if (!isDown) return;
+        var delta = e.pageX - startX;
+        if (Math.abs(delta) > 4) {
+          hasDragged = true;
+          carousel.classList.add('is-dragging');
+          window._setCursorLock('grabbing');
+        }
+        carousel.scrollLeft = scrollLeft - delta;
+      });
+
+      carousel.addEventListener('click', function(e) {
+        if (hasDragged) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          hasDragged = false;
+        }
+      }, true);
+    });
   });
 })();
 </script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -945,6 +945,96 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
 .team-tooltip:hover::after {
     opacity: 1;
 }
+
+/* Project intro two-column layout (sidebar variant) */
+.project-intro-grid {
+    display: flex;
+    gap: 48px;
+    align-items: flex-start;
+    margin: 1.5em 0 2.5em;
+}
+.project-intro-grid__content {
+    flex: 1 1 0;
+    min-width: 0;
+}
+.project-intro-grid__sidebar {
+    flex: 0 0 210px;
+    width: 210px;
+}
+.sidebar-logo {
+    height: 30px;
+    width: auto;
+    max-width: 100%;
+    object-fit: contain;
+    object-position: left center;
+    display: block;
+    margin-bottom: 1.6em;
+}
+.sidebar-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 1.1em;
+}
+.sidebar-meta__item {}
+.sidebar-meta__label {
+    font-size: 0.62em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #aaa;
+    margin-bottom: 0.45em;
+}
+.sidebar-meta__value {
+    font-size: 0.85em;
+    color: #333;
+    line-height: 1.5;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.contrib-tag {
+    display: inline-block;
+    font-size: 0.8em;
+    font-weight: 500;
+    border: 1px solid rgba(0,0,0,0.18);
+    border-radius: 20px;
+    padding: 2px 10px;
+    color: rgba(0,0,0,0.6);
+    background: transparent;
+}
+.team-tag {
+    display: inline-block;
+    font-size: 0.8em;
+    font-weight: 500;
+    border: 1px solid rgba(0,0,0,0.18);
+    border-radius: 20px;
+    padding: 2px 10px;
+    color: rgba(0,0,0,0.6);
+    background: transparent;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+.team-tag:hover {
+    background: rgba(184,150,58,0.1);
+    border-color: rgba(184,150,58,0.5);
+    color: #6b5020;
+}
+.team-tag.team-tooltip {
+    border-bottom: none;
+    padding-bottom: 2px;
+}
+@media (max-width: 640px) {
+    .project-intro-grid {
+        flex-direction: column;
+        gap: 24px;
+    }
+    .project-intro-grid__sidebar {
+        flex: none;
+        width: 100%;
+    }
+    .sidebar-logo { height: 24px; }
+}
+
 .tile-coming-soon {
     display: inline-block;
     font-size: 0.55em;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -19,21 +19,6 @@ body.layout--front {
     text-wrap: pretty;
 }
 
-body::after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 20px;
-    background: #B8963A;
-    pointer-events: none;
-}
-body.layout--front::after {
-    background: #3F4346;
-    transition: background-color 0.4s ease;
-}
-body.layout--front.bg-dark::after {
-    background: #F5F1E8;
-}
 
 .initial-content {
     opacity: 0;
@@ -478,7 +463,7 @@ body.layout--front.bg-dark .masthead__menu-item a[href="/info"]:hover {
     transform: translateY(6px);
     transition: opacity 0.3s ease 0.05s, transform 0.3s ease 0.05s;
 }
-.video-container:hover .project-title-name {
+.hero-tile:hover .project-title-name {
     opacity: 1;
     transform: translateY(0);
 }
@@ -493,7 +478,7 @@ body.layout--front.bg-dark .masthead__menu-item a[href="/info"]:hover {
     line-height: 1.2;
     margin-bottom: 2px;
 }
-.video-container:hover .tile-company {
+.hero-tile:hover .tile-company {
     opacity: 0.75;
     transform: translateY(0);
 }
@@ -547,7 +532,7 @@ body.layout--front.bg-dark .masthead__menu-item a[href="/info"]:hover {
     border-radius: 8px;
     overflow: hidden;
 }
-.video-container {
+.hero-tile {
     width: 50%;
     min-height: 300px;
     max-height: 400px;
@@ -627,7 +612,11 @@ body.layout--front.bg-dark .masthead__menu-item a[href="/info"]:hover {
 .container.scroll-test.dragging {
     cursor: grabbing;
 }
-.container.scroll-test .video-container {
+body.cursor-grabbing,
+body.cursor-grabbing * {
+    cursor: grabbing !important;
+}
+.container.scroll-test .hero-tile {
     flex: 0 0 auto;
     width: 85vw;
     max-width: 900px;
@@ -651,11 +640,12 @@ body.layout--front.bg-dark .masthead__menu-item a[href="/info"]:hover {
     z-index: 1;
     pointer-events: none;
 }
-.container.scroll-test .video-container.is-active {
+.container.scroll-test .hero-tile.is-active {
     height: calc(56vh + 40px);
-}
-.container.scroll-test .video-container:not(.is-active) {
     cursor: pointer;
+}
+.container.scroll-test .hero-tile:not(.is-active) {
+    cursor: grab;
 }
 .masthead,
 .masthead__inner-wrap,
@@ -663,37 +653,37 @@ body.layout--front.bg-dark .masthead__menu-item a[href="/info"]:hover {
     background-color: transparent !important;
     border-bottom: none !important;
 }
-a.video-container:link  { color: rgba(255,255,255,1.0); text-decoration: none !important; }
-a.video-container:visited,
-a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !important; }
+a.hero-tile:link  { color: rgba(255,255,255,1.0); text-decoration: none !important; }
+a.hero-tile:visited,
+a.hero-tile:hover { color: rgba(255,255,255,.75); text-decoration: none !important; }
 
 /* desktop: greyscale until hover or active */
 @media (hover: hover) {
-    .video-container {
+    .hero-tile {
         filter: grayscale(100%);
         transition: filter 0.3s ease, height 0.3s ease;
     }
-    .video-container:hover,
-    .video-container.is-active {
+    .hero-tile:hover,
+    .hero-tile.is-active {
         filter: grayscale(0%);
     }
 }
 
 /* mobile: scroll into view reveals color, animations always running */
 @media (hover: none) {
-    .video-container {
+    .hero-tile {
         filter: grayscale(100%);
         transition: filter 0.6s ease;
     }
-    .video-container.in-view {
+    .hero-tile.in-view {
         filter: grayscale(0%);
     }
-    .video-container.in-view .tile-company,
-    .video-container.in-view .project-title-name {
+    .hero-tile.in-view .tile-company,
+    .hero-tile.in-view .project-title-name {
         opacity: 0.75;
         transform: translateY(0);
     }
-    .video-container.in-view .project-title-name {
+    .hero-tile.in-view .project-title-name {
         opacity: 1;
     }
 }
@@ -730,8 +720,8 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
         justify-content: center;
     }
     .hero-intro h1 { margin: 0; }
-    .video-container { width: 100%; min-height: 80vw; max-height: none; }
-    .video-container p { padding-bottom: 1.3em; }
+    .hero-tile { width: 100%; min-height: 80vw; max-height: none; }
+    .hero-tile p { padding-bottom: 1.3em; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -946,6 +936,28 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     opacity: 1;
 }
 
+/* Project pagination footer */
+.project-footer-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1em 0 8em;
+    border-top: 1px solid rgba(0, 0, 0, 0.18);
+    margin-top: 4em;
+}
+.project-footer-nav a {
+    font-size: 0.8em;
+    font-weight: 400;
+    color: #999;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+.project-footer-nav a:hover {
+    color: #333;
+}
+
 /* Project intro two-column layout (sidebar variant) */
 .project-intro-grid {
     display: flex;
@@ -962,9 +974,8 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     width: 210px;
 }
 .sidebar-logo {
-    height: 30px;
-    width: auto;
-    max-width: 100%;
+    width: 100%;
+    height: 80px;
     object-fit: contain;
     object-position: left center;
     display: block;
@@ -1003,25 +1014,7 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     background: transparent;
 }
 .team-tag {
-    display: inline-block;
-    font-size: 0.8em;
-    font-weight: 500;
-    border: 1px solid rgba(0,0,0,0.18);
-    border-radius: 20px;
-    padding: 2px 10px;
-    color: rgba(0,0,0,0.6);
-    background: transparent;
-    cursor: pointer;
-    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-.team-tag:hover {
-    background: rgba(184,150,58,0.1);
-    border-color: rgba(184,150,58,0.5);
-    color: #6b5020;
-}
-.team-tag.team-tooltip {
-    border-bottom: none;
-    padding-bottom: 2px;
+    font-size: 0.85em;
 }
 @media (max-width: 640px) {
     .project-intro-grid {
@@ -1032,7 +1025,160 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
         flex: none;
         width: 100%;
     }
-    .sidebar-logo { height: 24px; }
+    .sidebar-logo { height: 40px; }
+}
+
+/* Horizontal scroll carousel for multi-image galleries inside project sections */
+.project-section figure.half,
+.project-section figure.third,
+.project-section figure.quarter {
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    overflow-x: auto !important;
+    overflow-y: visible !important;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    gap: 12px;
+    width: 100vw !important;
+    margin-left: calc(-50vw + 50%) !important;
+    margin-right: 0 !important;
+    margin-top: 1.25em !important;
+    margin-bottom: 1.5em !important;
+    padding: 0 32px 18px !important;
+    box-sizing: border-box !important;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0,0,0,0.15) transparent;
+    cursor: grab;
+    user-select: none;
+    -webkit-mask-image: linear-gradient(to right, transparent 0px, black 80px, black calc(100% - 80px), transparent 100%);
+    mask-image: linear-gradient(to right, transparent 0px, black 80px, black calc(100% - 80px), transparent 100%);
+}
+/* Fade only where there is more to scroll */
+.project-section figure.half.scroll-at-start,
+.project-section figure.third.scroll-at-start,
+.project-section figure.quarter.scroll-at-start {
+    -webkit-mask-image: linear-gradient(to right, black 0px, black calc(100% - 80px), transparent 100%);
+    mask-image: linear-gradient(to right, black 0px, black calc(100% - 80px), transparent 100%);
+}
+.project-section figure.half.scroll-at-end,
+.project-section figure.third.scroll-at-end,
+.project-section figure.quarter.scroll-at-end {
+    -webkit-mask-image: linear-gradient(to right, transparent 0px, black 80px, black 100%);
+    mask-image: linear-gradient(to right, transparent 0px, black 80px, black 100%);
+}
+.project-section figure.half.scroll-at-start.scroll-at-end,
+.project-section figure.third.scroll-at-start.scroll-at-end,
+.project-section figure.quarter.scroll-at-start.scroll-at-end {
+    -webkit-mask-image: none;
+    mask-image: none;
+}
+.project-section figure.half.is-dragging,
+.project-section figure.third.is-dragging,
+.project-section figure.quarter.is-dragging {
+    cursor: grabbing;
+    scroll-snap-type: none;
+}
+.project-section figure.half.is-dragging *,
+.project-section figure.third.is-dragging *,
+.project-section figure.quarter.is-dragging * {
+    cursor: grabbing !important;
+}
+.project-section figure.half::before,
+.project-section figure.half::after,
+.project-section figure.third::before,
+.project-section figure.third::after {
+    display: none !important;
+}
+.project-section figure.half a,
+.project-section figure.third a,
+.project-section figure.quarter a {
+    flex: 0 0 auto !important;
+    float: none !important;
+    width: auto !important;
+    margin: 0 !important;
+    scroll-snap-align: start;
+    display: block;
+    cursor: grab;
+}
+.project-section figure.half.is-dragging a,
+.project-section figure.third.is-dragging a,
+.project-section figure.quarter.is-dragging a {
+    cursor: grabbing !important;
+}
+.project-section figure.half img,
+.project-section figure.third img,
+.project-section figure.quarter img {
+    height: 560px !important;
+    width: auto !important;
+    max-width: none !important;
+    object-fit: cover;
+    border-radius: 4px;
+    display: block;
+    -webkit-user-drag: none;
+    user-select: none;
+    pointer-events: none;
+}
+.project-section figure.half figcaption,
+.project-section figure.third figcaption {
+    display: none;
+}
+
+/* Project section with full-bleed gradient background */
+.project-section {
+    position: relative;
+    margin-top: 3em;
+    padding-top: 2.5em;
+}
+.project-eyebrow {
+    font-size: 0.65em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #aaa;
+    margin: 0 0 0.3em;
+}
+.project-icon {
+    font-size: 0.85em;
+    margin-right: 0.2em;
+    vertical-align: middle;
+}
+:root {
+    --section-color: 215, 220, 228;
+}
+/* Per-page section gradient colors — lightened 20% toward white from home tile colors */
+body.page--jobs          { --section-color: 214, 208, 223; } /* #321261 purple */
+body.page--workflows     { --section-color: 236, 212, 241; } /* #9F29B7 purple */
+body.page--transcreation { --section-color: 249, 227, 224; } /* #E17463 coral */
+body.page--highlight     { --section-color: 204, 216, 213; } /* #003D2F green */
+.project-section::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100vw;
+    height: 320px;
+    background: linear-gradient(to bottom, rgb(var(--section-color)) 0%, rgba(255,255,255,0) 100%);
+    z-index: -1;
+    pointer-events: none;
+}
+/* Gradient lead-in for single-project pages (first h2 directly after intro grid) */
+.project-intro-grid ~ h2:first-of-type {
+    position: relative;
+    margin-top: 2.5em;
+    padding-top: 2em;
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100vw;
+        height: 520px;
+        background: linear-gradient(to bottom, rgb(var(--section-color)) 0%, rgba(255,255,255,0) 100%);
+        z-index: -1;
+        pointer-events: none;
+    }
 }
 
 .tile-coming-soon {
@@ -1051,8 +1197,8 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     transform: translateY(6px);
     transition: opacity 0.3s ease 0.1s, transform 0.3s ease 0.1s;
 }
-.video-container:hover .tile-coming-soon,
-.video-container.in-view .tile-coming-soon {
+.hero-tile:hover .tile-coming-soon,
+.hero-tile.in-view .tile-coming-soon {
     opacity: 1;
     transform: translateY(0);
 }
@@ -1066,14 +1212,14 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     transform: translateY(6px);
     transition: opacity 0.3s ease 0.05s, transform 0.3s ease 0.05s;
 }
-.video-container:hover .tile-title-row,
-.video-container.in-view .tile-title-row {
+.hero-tile:hover .tile-title-row,
+.hero-tile.in-view .tile-title-row {
     opacity: 1;
     transform: translateY(0);
 }
 /* Children inside the row are static — the row itself animates */
-.video-container:hover .tile-title-row > .project-title-name,
-.video-container:hover .tile-title-row > .tile-coming-soon {
+.hero-tile:hover .tile-title-row > .project-title-name,
+.hero-tile:hover .tile-title-row > .tile-coming-soon {
     opacity: 1;
     transform: none;
     transition: none;
@@ -1086,35 +1232,6 @@ a.video-container:hover { color: rgba(255,255,255,.75); text-decoration: none !i
     margin-top: 0;
 }
 
-/* Fixed prev/next arrows on project pages */
-.project-nav-arrow {
-    position: fixed;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 200;
-    width: 44px;
-    height: 44px;
-    border-radius: 50%;
-    background: rgba(255,255,255,0.82);
-    border: 1px solid rgba(0,0,0,0.12);
-    box-shadow: 0 2px 12px rgba(0,0,0,0.14);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333;
-    text-decoration: none !important;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-}
-.project-nav-arrow:hover {
-    background: rgba(255,255,255,0.98);
-    box-shadow: 0 4px 20px rgba(0,0,0,0.22);
-    color: #111;
-}
-.project-nav-arrow--left  { left: 16px; }
-.project-nav-arrow--right { right: 16px; }
-@media (max-width: 768px) {
-    .project-nav-arrow { display: none; }
-}
 
 /* Transcreation */
 .anim-tc { display: flex; align-items: center; gap: 20px; }

--- a/highlight-recruiting.md
+++ b/highlight-recruiting.md
@@ -4,58 +4,57 @@ hide_footer: true
 layout: default
 toc: false
 permalink: /highlight-recruiting
-classes: page--project page--highlight-recruiting
+classes: page--project page--highlight-recruiting page--highlight
 ---
 
-<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+<div class="project-intro-grid">
+<div class="project-intro-grid__content" markdown="1">
 
+<span class="project-subheader">Highlight Recruiting</span>
 # Getting Recruiting on Rails
-*From Manual Spreadsheets to Automated System*
-{: .notice}
-
-![Getting Recruiting on Rails — Highlight project overview](/assets/img/hl-rec-00-hero.jpg)
-
----
-
-<div class="case-meta">
-  <div class="case-meta__item">
-    <div class="case-meta__label">Role</div>
-    <div class="case-meta__value">UX Design &middot; Systems Design &middot; Research</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Scope</div>
-    <div class="case-meta__value">
-      <span class="scope-tag">Discovery</span>
-      <span class="scope-tag">Research</span>
-      <span class="scope-tag">Design</span>
-      <span class="scope-tag">Launch</span>
-    </div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Duration</div>
-    <div class="case-meta__value">Jan 2024&ndash;Present</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Team</div>
-    <div class="case-meta__value">
-      <span class="team-tooltip" data-tooltip="Justin Pocta">Design</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Andrew Shin, Emily Sutton (PM) · Deirdre Norris (VP Product)">Product</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Andrew Sidesinger · Brandon Reno · Matt Magnotta · Seth McCarthy · Sam Hanes · Russell Kennington · Sophie McGarity · Michael Funk">Engineering</span>
-    </div>
-  </div>
-</div>
-
-## Context
 
 I joined **Highlight** in January 2024 during a pivotal shift — the company was evolving from a research services model toward a dedicated software product. I was brought on to help build the internal systems that would support that growth, starting with recruiting.
 
-![Context: What Customer Brings → What Highlight Offers](/assets/img/hl-rec-01-context.jpg)
-
----
+</div>
+<aside class="project-intro-grid__sidebar">
+  <img src="/assets/img/highlight-logo.svg" alt="Highlight" class="sidebar-logo">
+  <div class="sidebar-meta">
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">My Role</div>
+      <div class="sidebar-meta__value">Product Designer, Highlight</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Duration</div>
+      <div class="sidebar-meta__value">Jan 2024&ndash;Present</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Contributions</div>
+      <div class="sidebar-meta__value">
+        <span class="contrib-tag">Discovery</span>
+        <span class="contrib-tag">Research</span>
+        <span class="contrib-tag">Design</span>
+        <span class="contrib-tag">Launch</span>
+      </div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Teams</div>
+      <div class="sidebar-meta__value">
+        <span class="team-tag team-tooltip" data-tooltip="Justin Pocta">Design</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Andrew Shin · Emily Sutton (PM) · Deirdre Norris (VP Product)">Product</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Andrew Sidesinger · Brandon Reno · Matt Magnotta · Seth McCarthy · Sam Hanes · Russell Kennington · Sophie McGarity · Michael Funk">Engineering</span>
+      </div>
+    </div>
+  </div>
+</aside>
+</div>
 
 ## The Problem
+
+![Getting Recruiting on Rails — Highlight project overview](/assets/img/hl-rec-00-hero.jpg)
+
+![Context: What Customer Brings → What Highlight Offers](/assets/img/hl-rec-01-context.jpg)
 
 Highlight was wanting to scale fast, but their core recruiting operations were still running like a small agency—manual, disconnected, and unsustainable.
 
@@ -65,11 +64,11 @@ Highlight was wanting to scale fast, but their core recruiting operations were s
 
 **Criteria selection was frustrating and lacked clarity** — Poor labeling, a tedious multi-step process, and unclear options made targeting inefficient.
 
----
+<div class="project-section" markdown="1">
 
 ## My Process
 
-- **Mapped internal workflows** — Gained understanding of how recruiting happens: CSV up/downloads, email address exports to send recruit emails, monitoring manual "dashboards"
+- **Mapped internal workflows** — Gained understanding of how recruiting happens: CSV up/downloads, email address exports to send recruit emails, monitoring manual “dashboards”
 - **Gathered stakeholder input** — Discussions with C-Level, Product, Customer Success, and Engineering on pain points and constraints, and to gather buy-in and support
 - **Audited data collection** — Analyzed how recruit data was gathered and identified efficiency barriers
 - **Diagrams to express concepts and mental models** — As words tend to get very muddled, I leverage simple visuals to confirm structures and flows
@@ -83,7 +82,7 @@ Highlight was wanting to scale fast, but their core recruiting operations were s
 
 ![Process: Diagramming and Wireframing — quick wireframes with PM/Eng, confirming recruit structures with CE](/assets/img/hl-rec-05-wireframing.jpg)
 
----
+</div>
 
 ## Before: Recruiting via Downloads
 
@@ -103,7 +102,7 @@ Two early directions: a sentence-style audience builder that made the query logi
 
 ![Exploration: Deeper dive on Criteria/Answer Selection](/assets/img/hl-rec-07-criteria-exploration.jpg)
 
-Criteria selection was one of the most painful parts of the old experience. These explorations tested different models — from a card-based Global/Test Group structure with tag-style answers on the left, to a "Configure Dimensions" panel on the right that let users browse and select criteria by category. The sidebar approach won out: it gave users persistent visibility into what they'd configured without burying it in a modal flow.
+Criteria selection was one of the most painful parts of the old experience. These explorations tested different models — from a card-based Global/Test Group structure with tag-style answers on the left, to a “Configure Dimensions” panel on the right that let users browse and select criteria by category. The sidebar approach won out: it gave users persistent visibility into what they’d configured without burying it in a modal flow.
 
 ---
 
@@ -113,23 +112,25 @@ Criteria selection was one of the most painful parts of the old experience. Thes
 
 The sidebar evolved into the primary interaction surface — giving users at-a-glance visibility of all Test Groups and their criteria without disrupting the main flow. Language and labeling went through multiple rounds of internal and external usability testing before landing.
 
----
+<div class="project-section" markdown="1">
 
 ## Production
 
 ### Customer Version
 
-![Production: Customer version — evolved from Admin App's UX](/assets/img/hl-rec-10-production-customer.jpg)
+![Production: Customer version — evolved from Admin App’s UX](/assets/img/hl-rec-10-production-customer.jpg)
 
-The customer-facing version evolved from the Admin App's UX patterns, adapted for customers building their own projects. With a clean "Qualifying Criteria" sidebar and Test Group management, customers could now actively configure their own recruiting instead of relying on internal handoffs.
+The customer-facing version evolved from the Admin App’s UX patterns, adapted for customers building their own projects. With a clean “Qualifying Criteria” sidebar and Test Group management, customers could now actively configure their own recruiting instead of relying on internal handoffs.
 
 ### Admin Version
 
 ![Production: Admin version — full recruiting workflow](/assets/img/hl-rec-11-production-admin.jpg)
 
-The admin app gives the internal team full control — Define and Finalize tabs, Test Group management with match counts, "Start Recruiting" / "Complete Recruit" actions, and the same criteria sidebar architecture refined through months of iteration.
+The admin app gives the internal team full control — Define and Finalize tabs, Test Group management with match counts, “Start Recruiting” / “Complete Recruit” actions, and the same criteria sidebar architecture refined through months of iteration.
 
----
+</div>
+
+<div class="project-section" markdown="1">
 
 ## Results, So Far
 
@@ -141,11 +142,11 @@ The admin app gives the internal team full control — Define and Finalize tabs,
 
 **Next phase** — Automated project and survey completion tracking.
 
-*\* this is a work in progress but we're closing in as these tools rely less on internal setup*
+*\* this is a work in progress but we’re closing in as these tools rely less on internal setup*
 
-<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
-  <span></span>
-  <a href="/opengov" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
 </div>
 
-<a href="/opengov" class="project-nav-arrow project-nav-arrow--right" aria-label="Next project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></a>
+<div class="project-footer-nav">
+  <a href="/">← Home</a>
+  <a href="/opengov">Next →</a>
+</div>

--- a/opengov.md
+++ b/opengov.md
@@ -89,14 +89,11 @@ galleryIA:
     alt: "DESCRIPTION"
 ---
 
-<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
-
-<span class="project-subheader">OpenGov Project</span>
-# Balancing the Budget App 
-{: .no_toc id="h1st"}
-
 <div class="project-intro-grid">
 <div class="project-intro-grid__content" markdown="1">
+
+<span class="project-subheader">OpenGov Projects</span>
+# Balancing the Budget App
 
 I took on the opportunity to join OpenGov as Sr. Product Designer for the Budgeting and Planning team in May 2021 on a UX team of 12 who were managing 4 apps across the platform.
 
@@ -124,11 +121,14 @@ During my time there, I supported the engineering and product teams launch work 
       </div>
     </div>
     <div class="sidebar-meta__item">
-      <div class="sidebar-meta__label">Team</div>
+      <div class="sidebar-meta__label">Teams</div>
       <div class="sidebar-meta__value">
         <span class="team-tag team-tooltip" data-tooltip="Justin Pocta">Design</span>
+        <span class="meta-sep">&middot;</span>
         <span class="team-tag team-tooltip" data-tooltip="Lalitha Balasubramhanya (Sr. Director PM) · Christine Liu (PM)">Product</span>
+        <span class="meta-sep">&middot;</span>
         <span class="team-tag team-tooltip" data-tooltip="Kim Henry (Lead UX Researcher)">Research</span>
+        <span class="meta-sep">&middot;</span>
         <span class="team-tag team-tooltip" data-tooltip="Dale (FE Lead) · Wei Huang (Sr. Engineering Manager)">Engineering</span>
       </div>
     </div>
@@ -136,9 +136,12 @@ During my time there, I supported the engineering and product teams launch work 
 </aside>
 </div>
 
+<div class="project-section" style="--section-color: 232,239,245;" markdown="1">
+
 ***
-# Project: Wayfinding Clarification
-![](../assets/img/OpenGov-Project-Header-Wayfinding.png)
+
+<p class="project-eyebrow">Project</p>
+<h1><span class="project-icon">🧭</span> Wayfinding Clarification</h1>
 
 ## Problem Statement & Kickoff
 **Goal:** Improve clarity of a user’s current location in the app and the app infrastructure overall
@@ -192,10 +195,14 @@ These concepts were really enjoyable to talk through with members of the team be
 
 {% include gallery layout="half" id="galleryWayfindingFuture" caption="Future Vision" %}
 
-***
-# Project: Budget Organization
+</div>
 
-![right-aligned-image](../assets/img/OpenGov-Project-Header-Budget-Organization.png){: .fifty}
+<div class="project-section" style="--section-color: 232,239,245;" markdown="1">
+
+***
+
+<p class="project-eyebrow">Project</p>
+<h1><span class="project-icon">📂</span> Budget Organization</h1>
 
 ## Project Goal & Kickoff
 The initial direction were told was to “simply add folders” to allow users to organize their budgets due to the Budgets list being a confusing and problematic part of the site. Upon partnering with the product manager, we gathered more data to validate this request, as something felt off about it based on what we saw across many customer accounts.
@@ -218,12 +225,16 @@ My goal was to keep the existing design to maintain a smaller scope of work, whi
 ## Results & Lessons
 Ran an in-app feedback survey to a targeted group of users. Received 88% positive feedback from the 9 replies. This also gave us additional feedback and requests that we could follow up on to continue enhancing this experience for our customers.
 
-Where we landed was not that different, but it added control and clarity. This is what we were hearing from users. 
+Where we landed was not that different, but it added control and clarity. This is what we were hearing from users.
+
+</div>
+
+<div class="project-section" style="--section-color: 232,239,245;" markdown="1">
 
 ***
-# Project: Improving Reports Customer Journey
 
-![](../assets/img/OpenGov-Project-Header-Budget-Reporting-Workshop.png)
+<p class="project-eyebrow">Project</p>
+<h1><span class="project-icon">📊</span> Improving Reports Customer Journey</h1>
 
 ## Project Goal & Kickoff
 Our team had identified a challenging user flow which I had heard many times myself from internal interviews with our customer-oriented subject matter experts. Creating and finding “Reports” was difficult. It was also owned by another team, so we needed to connect and collaborate on how things worked and what we could do.
@@ -258,10 +269,9 @@ Explorations where I aimed to reduce the user journey by creating more guidance 
 
 Thanks for reading!
 
-<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
-  <a href="/highlight-recruiting" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
-  <a href="/smartling-jobs" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
 </div>
 
-<a href="/highlight-recruiting" class="project-nav-arrow project-nav-arrow--left" aria-label="Previous project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></a>
-<a href="/smartling-jobs" class="project-nav-arrow project-nav-arrow--right" aria-label="Next project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></a>
+<div class="project-footer-nav">
+  <a href="/highlight-recruiting">← Previous</a>
+  <a href="/smartling-jobs">Next →</a>
+</div>

--- a/opengov.md
+++ b/opengov.md
@@ -91,51 +91,49 @@ galleryIA:
 
 <a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
 
-# OpenGov Projects
-*Senior Product Designer, Budgeting - 2021-22*
-{: .notice}
-
 <span class="project-subheader">A collection of UX work at OpenGov</span>
 # Balancing the Budget App 
 {: .no_toc id="h1st"}
 
-![img](../assets/img/OpenGov-Logo.png)
- {: .third-right}
+<div class="project-intro-grid">
+<div class="project-intro-grid__content" markdown="1">
 
 I took on the opportunity to join OpenGov as Sr. Product Designer for the Budgeting and Planning team in May 2021 on a UX team of 12 who were managing 4 apps across the platform.
 
 During my time there, I supported the engineering and product teams launch work from other designers as I was onboarded, partnered with our UX Researcher and CSM team to interview customers, designed projects alongside Product Manager, and collaborated with the Engineering and QA team to review, refine, and help get projects out the door.
 
-<div class="case-meta">
-  <div class="case-meta__item">
-    <div class="case-meta__label">Role</div>
-    <div class="case-meta__value">UX Design &middot; Research</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Scope</div>
-    <div class="case-meta__value">
-      <span class="scope-tag">Discovery</span>
-      <span class="scope-tag">Research</span>
-      <span class="scope-tag">Design</span>
-      <span class="scope-tag">Launch</span>
+</div>
+<aside class="project-intro-grid__sidebar">
+  <img src="../assets/img/OpenGov-Logo.png" alt="OpenGov" class="sidebar-logo">
+  <div class="sidebar-meta">
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">My Role</div>
+      <div class="sidebar-meta__value">Senior Product Designer, Budgeting App</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Duration</div>
+      <div class="sidebar-meta__value">2021 Q3&ndash;Q4</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Contributions</div>
+      <div class="sidebar-meta__value">
+        <span class="contrib-tag">Discovery</span>
+        <span class="contrib-tag">Research</span>
+        <span class="contrib-tag">Design</span>
+        <span class="contrib-tag">Launch</span>
+      </div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Team</div>
+      <div class="sidebar-meta__value">
+        <span class="team-tag team-tooltip" data-tooltip="Justin Pocta">Design</span>
+        <span class="team-tag team-tooltip" data-tooltip="Lalitha Balasubramhanya (Sr. Director PM) · Christine Liu (PM)">Product</span>
+        <span class="team-tag team-tooltip" data-tooltip="Kim Henry (Lead UX Researcher)">Research</span>
+        <span class="team-tag team-tooltip" data-tooltip="Dale (FE Lead) · Wei Huang (Sr. Engineering Manager)">Engineering</span>
+      </div>
     </div>
   </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Duration</div>
-    <div class="case-meta__value">2021 Q3&ndash;Q4</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Team</div>
-    <div class="case-meta__value">
-      <span class="team-tooltip" data-tooltip="Justin Pocta">Design</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Lalitha Balasubramhanya (Sr. Director PM) · Christine Liu (PM)">Product</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Kim Henry (Lead UX Researcher)">Research</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Dale (FE Lead) · Wei Huang (Sr. Engineering Manager)">Engineering</span>
-    </div>
-  </div>
+</aside>
 </div>
 
 ***

--- a/opengov.md
+++ b/opengov.md
@@ -91,7 +91,7 @@ galleryIA:
 
 <a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
 
-<span class="project-subheader">A collection of UX work at OpenGov</span>
+<span class="project-subheader">OpenGov Project</span>
 # Balancing the Budget App 
 {: .no_toc id="h1st"}
 

--- a/smartling-jobs.md
+++ b/smartling-jobs.md
@@ -2,6 +2,7 @@
 title: Jobs Dashboard
 hide_footer: true
 layout: default
+classes: page--jobs
 toc: false
 toc_sticky: true
 toc_label: "Project Index"
@@ -62,52 +63,49 @@ galleryFinal:
     alt: " "
     title: " "
 ---
-<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
-
-# Project: Jobs Dashboard
-*Product Designer @ Smartling, 2017-21*
-{: .notice}
+<div class="project-intro-grid">
+<div class="project-intro-grid__content" markdown="1">
 
 <span class="project-subheader">Jobs Dashboard, Extreme Makeover</span>
 # Rebooting Jobs
-{: id="h1st"}
-
-
-![Smartling](/assets/img/Smartling-Logo.png)
-{: .third-right}
 
 Smartling use revolves around daily requests for original content to be translated, edited, reviewed and published.
 
 It is fast paced and involves sophisticated workflow processes, with large teams and varying user permission levels, project structures, toolsets. Tracking these job requests is a critical piece of the day to day.
 
-<div class="case-meta">
-  <div class="case-meta__item">
-    <div class="case-meta__label">Role</div>
-    <div class="case-meta__value">UX Design &middot; Research</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Scope</div>
-    <div class="case-meta__value">
-      <span class="scope-tag">Discovery</span>
-      <span class="scope-tag">Research</span>
-      <span class="scope-tag">Design</span>
-      <span class="scope-tag">Launch</span>
+</div>
+<aside class="project-intro-grid__sidebar">
+  <img src="/assets/img/Smartling-Logo.png" alt="Smartling" class="sidebar-logo">
+  <div class="sidebar-meta">
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">My Role</div>
+      <div class="sidebar-meta__value">Product Designer, Smartling</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Duration</div>
+      <div class="sidebar-meta__value">Jan 2020&ndash;Aug 2020</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Contributions</div>
+      <div class="sidebar-meta__value">
+        <span class="contrib-tag">Discovery</span>
+        <span class="contrib-tag">Research</span>
+        <span class="contrib-tag">Design</span>
+        <span class="contrib-tag">Launch</span>
+      </div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Teams</div>
+      <div class="sidebar-meta__value">
+        <span class="team-tag team-tooltip" data-tooltip="Justin Pocta">Design</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Sophia Lazare (PM)">Product</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Jeremy Shankle · Dmitry Masley · Oleksandr Tymchenko · Pavlo Myrotiuk · Valerii Linetskyi · Sergey Chichulin · Yurii Beiko · Xiaoyun Yang · Rich Tam · Dominic DeMarco">Engineering</span>
+      </div>
     </div>
   </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Duration</div>
-    <div class="case-meta__value">Jan 2020&ndash;Aug 2020</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Team</div>
-    <div class="case-meta__value">
-      <span class="team-tooltip" data-tooltip="Justin Pocta">Design</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Sophia Lazare (PM)">Product</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Jeremy Shankle · Dmitry Masley · Oleksandr Tymchenko · Pavlo Myrotiuk · Valerii Linetskyi · Sergey Chichulin · Yurii Beiko · Xiaoyun Yang · Rich Tam · Dominic DeMarco">Engineering</span>
-    </div>
-  </div>
+</aside>
 </div>
 
 ## Discovering Deep Roots
@@ -132,9 +130,12 @@ All in all, it was barebones and lacking in consideration for the needs of a Loc
 
 ---
 
+<div class="project-section" markdown="1">
+
 ## **Initial Design for Customers & Translators**
 
 {% include gallery layout="half" id="galleryInitial" caption="" %}
+</div>
 
 ## Listening In
 
@@ -144,9 +145,12 @@ We collected input that helped to shape incorrect assumptions and validate aspec
 
 In this early iteration, we found that assignees were not valuable to users—general workflow status was critical. 
 
+<div class="project-section" markdown="1">
+
 ## **Design Iterations**
 
 {% include gallery layout="third" id="galleryIterations" caption="" %}
+</div>
 
 ## Data Grid vs Table
 
@@ -162,10 +166,7 @@ Future phases are planned to catch up the code to the UX vision where we intend 
 
 {% include gallery layout="" id="galleryFinal" caption="" %}
 
-<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
-  <a href="/opengov" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
-  <a href="/smartling-workflows" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+<div class="project-footer-nav">
+  <a href="/opengov">← Previous</a>
+  <a href="/smartling-workflows">Next →</a>
 </div>
-
-<a href="/opengov" class="project-nav-arrow project-nav-arrow--left" aria-label="Previous project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></a>
-<a href="/smartling-workflows" class="project-nav-arrow project-nav-arrow--right" aria-label="Next project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></a>

--- a/smartling-transcreation.md
+++ b/smartling-transcreation.md
@@ -2,6 +2,7 @@
 title: Transcreation
 hide_footer: true
 layout: default
+classes: page--transcreation
 toc: false
 toc_sticky: false
 toc_label: "Project Index"
@@ -29,50 +30,47 @@ galleryIterations:
     title: ""
 
 ---
-<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
+<div class="project-intro-grid">
+<div class="project-intro-grid__content" markdown="1">
 
-# Project: Transcreation Tool
-*Product Designer @ Smartling, 2017-21*
-{: .notice}
-
-<span class="project-subheader">CREATING TRANSCREATION</span>
+<span class="project-subheader">Creating Transcreation</span>
 # Building an innovative Transcreation tool from scratch
-{: id="h1st"}
 
+Over the course of 2019, the word “Transcreation” was being used more and more around the office. At the end of the year, it was finally pushed into high gear so we could begin to chip away at what we could offer our customers to give them access to a more creative form of translation _inside_ of our platform.
 
-![Smartling](/assets/img/Smartling-Logo.png)
-{: .third-right}
-
-Over the course of 2019, the word “Transcreation" was being used more and more around the office. At the end of the year, it was finally pushed into high gear so we could begin to chip away at what we could offer our customers to give them access to a more creative form of translation _inside_ of our platform.
-
-<div class="case-meta">
-  <div class="case-meta__item">
-    <div class="case-meta__label">Role</div>
-    <div class="case-meta__value">UX Design &middot; Research &middot; Handoff</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Scope</div>
-    <div class="case-meta__value">
-      <span class="scope-tag">Discovery</span>
-      <span class="scope-tag">Research</span>
-      <span class="scope-tag">Design</span>
-      <span class="scope-tag">Handoff</span>
+</div>
+<aside class="project-intro-grid__sidebar">
+  <img src="/assets/img/Smartling-Logo.png" alt="Smartling" class="sidebar-logo">
+  <div class="sidebar-meta">
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">My Role</div>
+      <div class="sidebar-meta__value">Product Designer, Smartling</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Duration</div>
+      <div class="sidebar-meta__value">Jan 2020&ndash;Jul 2020</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Contributions</div>
+      <div class="sidebar-meta__value">
+        <span class="contrib-tag">Discovery</span>
+        <span class="contrib-tag">Research</span>
+        <span class="contrib-tag">Design</span>
+        <span class="contrib-tag">Handoff</span>
+      </div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Teams</div>
+      <div class="sidebar-meta__value">
+        <span class="team-tag team-tooltip" data-tooltip="Justin Pocta · Frannie Laks">Design</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Sophia Lazare (PM) · Tobias Kahn (PM)">Product</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Anton Shanyuk (FE) · Keith Legin (Engineer Lead)">Engineering</span>
+      </div>
     </div>
   </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Duration</div>
-    <div class="case-meta__value">Jan 2020&ndash;Jul 2020</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Team</div>
-    <div class="case-meta__value">
-      <span class="team-tooltip" data-tooltip="Justin Pocta · Frannie Laks">Design</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Sophia Lazare (PM) · Tobias Kahn (PM)">Product</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Anton Shanyuk (FE) · Keith Legin (Engineer Lead)">Engineering</span>
-    </div>
-  </div>
+</aside>
 </div>
 
 ## Discovering Processes
@@ -117,17 +115,20 @@ As with a lot of our work, we often run into some technical challenges. Being ab
 
 During early investigation of other Transcreation tools and spreadsheet usage, we considered some of the oddities like repeating content unnecessarily and reducing the focus space of the transcreation and descriptive explanation themselves. Getting into the flow of writing and letting the linguist move quickly through brainstorming processes was not something they would want blocked, nor would they want to work without the clarity of visual context.
 
+<div class="project-section" markdown="1">
+
 ## **Design Iterations & Prototype**
 
 After nailing down the primary elements and a structure that would allow for giving the most space to the most valuable elements, we know we needed to focus on the interaction flow. We ran general test with a small group of linguists, having them walk us through what they expected might happen and identifying any language, iconography, or flows which were confusing or less discoverable.
 
 {% include gallery layout="half" id="galleryIterations" caption="" %}
+</div>
 
 ## UX Handoff
 
 In March of 2020, I got the pleasure of hiring on the second designer to our product team. Frannie Laks jumped in and quickly onboarded during the beginning of the pandemic. Within a short time, I was able to handoff the foundations I had laid for Transcreation and met with her and the PM regularly to help identify existing UX patterns, potentially new component needs, to recognize places where we were overbuilding beyond the MVP scope, and any prior interview data that could help us in closing off the project to get it out the door. I also set up several one-on-one sessions to work through specific aspects about Figma and its prototyping capabilities as well as the component structure since the rush to market was intense and I knew moving from Sketch to Figma takes a fair amount of adjustment.
 
-> “I absolutely love working on creative projects with our customers, and Smartling’s new Transcreation Tool makes it substantially more efficient to produce quality results," said Gabriela Ortiz, a professional Smartling translator in Argentina. “I no longer have to stare into the cells of a spreadsheet and circulate transcreations by email. Instead, I log into Smartling, write three options with back translations, and then communicate directly with the customer through the platform to ensure the work meets their expectations.”
+> “I absolutely love working on creative projects with our customers, and Smartling’s new Transcreation Tool makes it substantially more efficient to produce quality results,” said Gabriela Ortiz, a professional Smartling translator in Argentina. “I no longer have to stare into the cells of a spreadsheet and circulate transcreations by email. Instead, I log into Smartling, write three options with back translations, and then communicate directly with the customer through the platform to ensure the work meets their expectations.”
 
 ![Transcreation Demo to present the new tool to our customers as well as those interested in localization](../assets/img/Smartling-Transcreation-TC+demo+Screen+Shot+2021-04-02+at+1.11.07+AM.png)
 [Vimeo](https://vimeo.com/492149005)
@@ -140,10 +141,7 @@ Transcreation Demo to present the new tool to our customers as well as those int
 - Article: [Automating Transcreation](https://www.linkedin.com/pulse/automating-transcreation-joseph-kovalov/?trackingId=BSoligoMdVW7DjQ%2BobyuSg%3D%3D)
   
 
-<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
-  <a href="/smartling-workflows" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
-  <a href="/info" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+<div class="project-footer-nav">
+  <a href="/smartling-workflows">← Previous</a>
+  <a href="/info">Next →</a>
 </div>
-
-<a href="/smartling-workflows" class="project-nav-arrow project-nav-arrow--left" aria-label="Previous project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></a>
-<a href="/info" class="project-nav-arrow project-nav-arrow--right" aria-label="Next project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></a>

--- a/smartling-workflows.md
+++ b/smartling-workflows.md
@@ -2,6 +2,7 @@
 title: Workflows 2.0
 hide_footer: true
 layout: default
+classes: page--workflows
 toc: false
 toc_sticky: true
 toc_label: "Project Index"
@@ -60,49 +61,47 @@ galleryDecisionStepRules:
     title: ""
 ---
 
-<a href="/" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Back</a>
-
-# Project: Workflows 2.0
-*Product Designer @ Smartling, 2017-21*
-{: .notice}
+<div class="project-intro-grid">
+<div class="project-intro-grid__content" markdown="1">
 
 <span class="project-subheader">Workflows 2.0</span>
 # From basic linear processes into a transformed, automated dynamic translation workflow to fit real world needs of our sophisticated customers
-{: .no_toc id="h1st"}
-
-![Smartling Logo](../assets/img/Smartling-Logo.png)
-{: .third-right}
 
 From the beginning of my time at Smartling in late 2017, the team had a goal of refining the existing product, as well as going deeper by applying modern technologies such as powerful automations to allow our customers increase efficiency and reduce clicks. Our Workflows configuration was a prime feature to invest in this type of effect.
 
-<div class="case-meta">
-  <div class="case-meta__item">
-    <div class="case-meta__label">Role</div>
-    <div class="case-meta__value">UX Design &middot; Research</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Scope</div>
-    <div class="case-meta__value">
-      <span class="scope-tag">Discovery</span>
-      <span class="scope-tag">Research</span>
-      <span class="scope-tag">Design</span>
-      <span class="scope-tag">Launch</span>
+</div>
+<aside class="project-intro-grid__sidebar">
+  <img src="/assets/img/Smartling-Logo.png" alt="Smartling" class="sidebar-logo">
+  <div class="sidebar-meta">
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">My Role</div>
+      <div class="sidebar-meta__value">Product Designer, Smartling</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Duration</div>
+      <div class="sidebar-meta__value">Jan 2019&ndash;Apr 2019</div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Contributions</div>
+      <div class="sidebar-meta__value">
+        <span class="contrib-tag">Discovery</span>
+        <span class="contrib-tag">Research</span>
+        <span class="contrib-tag">Design</span>
+        <span class="contrib-tag">Launch</span>
+      </div>
+    </div>
+    <div class="sidebar-meta__item">
+      <div class="sidebar-meta__label">Teams</div>
+      <div class="sidebar-meta__value">
+        <span class="team-tag team-tooltip" data-tooltip="Justin Pocta">Design</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Franco Parico (PM)">Product</span>
+        <span class="meta-sep">&middot;</span>
+        <span class="team-tag team-tooltip" data-tooltip="Xiaoyun Yang (FE MVP) · Oleksandr Tymchenko (FE 1.0+) · Ben Loy (BE) · Dmitry Bochorishvili (BE)">Engineering</span>
+      </div>
     </div>
   </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Duration</div>
-    <div class="case-meta__value">Jan 2019&ndash;Apr 2019</div>
-  </div>
-  <div class="case-meta__item">
-    <div class="case-meta__label">Team</div>
-    <div class="case-meta__value">
-      <span class="team-tooltip" data-tooltip="Justin Pocta">Design</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Franco Parico (PM)">Product</span>
-      <span class="meta-sep">&middot;</span>
-      <span class="team-tooltip" data-tooltip="Xiaoyun Yang (FE MVP) · Oleksandr Tymchenko (FE 1.0+) · Ben Loy (BE) · Dmitry Bochorishvili (BE)">Engineering</span>
-    </div>
-  </div>
+</aside>
 </div>
 
 ## The Initial, Linear Flow
@@ -123,19 +122,20 @@ Working alongside Franco Parico, our PM for Workflows and MT tools, we kicked of
 
 ---
 
+<div class="project-section" markdown="1">
+
 ## Explorations of UI and Design Frameworks
 
 Discussions with the tech and product stakeholders helped us to assess potential tools and UI we could use. 3D Gamified visuals were noted, but discarded upon review as the goal of clear and quick UI was critical to the flow due to the list of workflows that a user would need to skim through and difficult to discover text at 45º angles was not optimal.
 
 A set of rough mockup to consider vertical alignment (problematic for finding the default flow from the alternate pathways), persistent step creation buttons (too cluttered), and other UI explorations to find the right look and feel for such a new approach to our platform.
 
-
 ![AWS 3D reference](../assets/img/Smartling-Workflows-aws-CTJsNcGUwAEa2BX.jpeg)
 {: .img-border}
 *AWS 3D reference*
 
-
 {% include gallery layout="half" id="galleryExplorations" caption="" %}
+</div>
 
 
 ---
@@ -176,10 +176,7 @@ Where we landed was thanks to the help of Product, Engineering and UX collaborat
 ### Managing Rules for Decision Steps
 <iframe src="https://www.youtube.com/embed/sB9zdrpP3j8?controls=0" title="YouTube video player"  class="youtube-handler" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-<div style="display:flex; justify-content:space-between; align-items:center; padding:1em 0 3em;">
-  <a href="/smartling-jobs" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">← Previous</a>
-  <a href="/smartling-transcreation" style="font-size:0.8em; font-weight:400; color:#999; text-transform:uppercase; letter-spacing:0.08em; text-decoration:none; transition:color 0.2s ease;" onmouseover="this.style.color='#333'" onmouseout="this.style.color='#999'">Next →</a>
+<div class="project-footer-nav">
+  <a href="/smartling-jobs">← Previous</a>
+  <a href="/smartling-transcreation">Next →</a>
 </div>
-
-<a href="/smartling-jobs" class="project-nav-arrow project-nav-arrow--left" aria-label="Previous project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></a>
-<a href="/smartling-transcreation" class="project-nav-arrow project-nav-arrow--right" aria-label="Next project"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></a>


### PR DESCRIPTION
## Summary
- Replaces old notice bar + floating logo with a two-column flexbox grid: body text left, sidebar right
- Sidebar contains: OpenGov logo, My Role, Duration, Contributions (outline pills), Team (tooltip tags with gold hover)
- Removes redundant "OpenGov Projects" h1 and notice bar since sidebar handles that context
- Updates subheader copy to "OpenGov Project"
- Adds all supporting CSS: `.project-intro-grid`, `.sidebar-meta`, `.contrib-tag`, `.team-tag` (with responsive mobile collapse)

## Test plan
- [ ] Visit /opengov — sidebar visible on right with logo, role, duration, contributions, team
- [ ] Hover team tags — gold tint fill appears
- [ ] Resize to mobile — columns stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)