### PR TITLE
Info page note + mobile Safari animation fix

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -258,6 +258,15 @@
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
         entry.target.classList.toggle('in-view', entry.isIntersecting);
+        if (entry.isIntersecting) {
+          // Safari suspends @keyframes on off-screen scroll-container elements;
+          // restart CSS animations from the beginning when the tile scrolls into view.
+          entry.target.querySelectorAll('.css-anim *').forEach(function(el) {
+            el.style.animationName = 'none';
+            void el.offsetWidth; // force reflow to flush the removal
+            el.style.animationName = '';
+          });
+        }
       });
     }, { threshold: 0.5 });
     tiles.forEach(function(tile) { observer.observe(tile); });

--- a/info.md
+++ b/info.md
@@ -26,10 +26,6 @@ I love working with teams that value asking questions. _Why are we creating a gi
 
 </div>
 
-<div class="fade-in-block" style="animation-delay:0.95s; border-left: 3px solid #D4B870; padding: 10px 18px; margin: 1.8em 0 1.8em; opacity: 0.75;">
-  <p style="margin: 0; font-size: 0.82em; font-style: italic; line-height: 1.6; color: inherit;">Pardon my portfolio's rough edges — I'm updating on a near-daily basis, adding and revising case studies, and exploring Claude Code for animation and other frontend enhancements. Enjoy the show.</p>
-</div>
-
 <div class="fade-in-block" style="animation-delay:1.05s; border: 2px solid #D4B870; border-radius: 6px; padding: 26px 32px 32px; margin: 1.5em 0 40px; text-align: center; box-sizing: border-box; overflow: hidden;">
   <p style="margin: 0 0 28px; font-weight: 400; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.1em; color: #999;">Get in Touch</p>
   <div style="display: flex; gap: 48px; justify-content: center;">
@@ -50,6 +46,10 @@ I love working with teams that value asking questions. _Why are we creating a gi
       <span style="font-size:0.78em;">Résumé</span>
     </a>
   </div>
+</div>
+
+<div class="fade-in-block" style="animation-delay:1.15s; margin: 1.8em 0 1.8em; opacity: 0.75;" markdown="1">
+  <p style="margin: 0; font-size: 0.9em; font-style: italic; font-family: Georgia, serif; line-height: 1.6; color: inherit;">Pardon my portfolio's rough edges. I'm updating on a near-daily basis, adding and revising case studies, and exploring Claude Code for animation and other frontend enhancements. Enjoy the show. Running on Github Pages, Jekyll, and iterating off of <a href="https://mmistakes.github.io/minimal-mistakes/" style="color:inherit;">Minimal Mistakes</a> theme.</p>
 </div>
 
 <div style="clear: both; padding-bottom: 40px;"></div>


### PR DESCRIPTION
## Summary
- Replaces verbose "This Site" section on info page with a single sentence tucked into the pardon callout; callout moved below Get in Touch box; styled serif, 0.9em, no left border
- Fixes CSS `@keyframes` animations (OG, Jobs, Workflows, Transcreation, spinning logo) freezing on mobile Safari — Safari suspends animations on off-screen elements inside horizontal scroll containers; IntersectionObserver now restarts them when each tile scrolls into view

## Test plan
- [ ] Visit `/info` — pardon note appears below contact box, serif, no border
- [ ] On mobile Safari, scroll through home tiles — all illustrations should animate when scrolled into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)