### PR TITLE
Hi page: disable double-tap zoom on mobile

### DIFF
--- a/hi.md
+++ b/hi.md
@@ -9,6 +9,9 @@ hide_footer: true
 ---
 
 <style>
+/* prevent double-tap zoom on mobile without disabling pinch-zoom */
+html { touch-action: manipulation; }
+
 /* ensure parent containers don't clip the card stack */
 .page__content,
 .initial-content {


### PR DESCRIPTION
## Summary
- Adds `touch-action: manipulation` to `html` on the /hi/ page
- Prevents accidental double-tap zoom that was misaligning elements
- Pinch-to-zoom still works (accessibility preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)