### PR TITLE
Hi page: Mastodon/Flickr app labels, dynamic post text size

### DIFF
--- a/_includes/flickr.html
+++ b/_includes/flickr.html
@@ -11,6 +11,7 @@
       <circle cx="8" cy="8" r="8" fill="#FF0084"/>
       <circle cx="26" cy="8" r="8" fill="#0063DC"/>
     </svg>
+    <span class="flickr-appname">Flickr</span>
     <a href="http://photos.justinpocta.com" class="flickr-handle" target="_blank" rel="noopener">@justinpocta</a>
   </div>
   <div id="flickr-grid" class="flickr-grid">
@@ -63,10 +64,14 @@
     flex: 0 0 auto;
     display: block;
   }
-  .flickr-handle {
-    font-weight: 600;
+  .flickr-appname {
+    font-weight: 700;
     font-size: 0.95rem;
-    color: inherit;
+  }
+  .flickr-handle {
+    font-weight: 400;
+    font-size: 0.95rem;
+    color: #888;
     text-decoration: none;
   }
   .flickr-handle:hover {

--- a/_includes/mastodon.html
+++ b/_includes/mastodon.html
@@ -43,10 +43,18 @@
     flex: 0 0 auto;
     display: block;
   }
-  .mastodon-handle {
-    font-weight: 600;
+  .mastodon-appname {
+    font-weight: 700;
     font-size: 0.95rem;
   }
+  .mastodon-handle {
+    font-weight: 400;
+    font-size: 0.95rem;
+    color: #888;
+  }
+  .social-post-text { font-size: 1.05rem; line-height: 1.5; margin: 0; }
+  .social-post-text.post-size-lg { font-size: 1.3rem; line-height: 1.4; }
+  .social-post-text.post-size-xl { font-size: 1.65rem; line-height: 1.3; }
   .mastodon-dot {
     color: #999;
   }
@@ -117,19 +125,26 @@
       "</svg>";
   }
 
+  function textLen(html) {
+    return html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim().length;
+  }
+
   function renderPost(post, index) {
     var date = new Date(post.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
     var handle = "@" + (post.account && post.account.username ? post.account.username : "justinpocta");
+    var len = textLen(post.content);
+    var sizeClass = len < 80 ? 'post-size-xl' : len < 200 ? 'post-size-lg' : '';
 
     return '<a class="social-post mastodon-card" href="' + post.url + '" target="_blank" rel="noopener">' +
       '<div class="mastodon-footer">' +
         mastodonIcon("mastodon-grad-" + index) +
+        '<span class="mastodon-appname">Mastodon</span>' +
         '<span class="mastodon-handle">' + escapeHtml(handle) + "</span>" +
         '<span class="mastodon-dot">&middot;</span>' +
         '<span class="mastodon-date">' + date + "</span>" +
       "</div>" +
       renderMedia(post.media_attachments) +
-      '<div class="social-post-text">' + post.content + "</div>" +
+      '<div class="social-post-text ' + sizeClass + '">' + post.content + "</div>" +
     "</a>";
   }
 


### PR DESCRIPTION
## Summary
- Mastodon header: "Mastodon @justinpocta · date" — app name bold, handle secondary
- Flickr header: "Flickr @justinpocta" — same pattern
- Mastodon post text scales by character count: <80 chars → 1.65rem, <200 chars → 1.3rem, longer → 1.05rem base

🤖 Generated with [Claude Code](https://claude.com/claude-code)