### PR TITLE
Hi page: fix dark mode signature logo (invert SVG)

### DIFF
--- a/hi.md
+++ b/hi.md
@@ -19,12 +19,14 @@ body { overflow-x: hidden; }
   html body .masthead .site-title,
   html body .masthead .site-title:visited,
   html body .masthead .greedy-nav a { color: #f0f0f0 !important; }
+  .site-title::before { filter: invert(1); }
   h1, h2, h3, p { color: #e8e8e8; }
 }
 html[data-theme="dark"] body { background-color: #1a1a1a !important; }
 html[data-theme="dark"] .masthead .site-title,
 html[data-theme="dark"] .masthead .site-title:visited,
 html[data-theme="dark"] .masthead .greedy-nav a { color: #f0f0f0 !important; }
+html[data-theme="dark"] .site-title::before { filter: invert(1); }
 html[data-theme="dark"] h1,
 html[data-theme="dark"] h2,
 html[data-theme="dark"] h3,


### PR DESCRIPTION
## Summary
- The signature logo uses a `::before` pseudo-element with `background-image: url(signature.svg)` — a black SVG
- `color: #f0f0f0` had no effect because `color` doesn't touch SVG background images
- Fix: `filter: invert(1)` on `.site-title::before` in dark mode — the theme already had `transition: filter 0.4s` wired up, so it transitions smoothly

## Test plan
- [ ] Load `/hi/` in dark mode — signature logo renders white
- [ ] Load `/hi/` in light mode — signature logo still renders black (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)