### PR TITLE
Hi page: show correct card peeking behind during drag

### DIFF
--- a/hi.md
+++ b/hi.md
@@ -335,6 +335,22 @@ html[data-theme="dark"] p { color: #e8e8e8; }
   function snapBack(card) {
     card.style.transition = '';
     card.style.transform = '';
+    updateStack();
+  }
+
+  function applyPreview(dx) {
+    if (Math.abs(dx) < 20) return;
+    var goingTo = dx > 0 ? mod(current - 1, total) : mod(current + 1, total);
+    cards.forEach(function (card, i) {
+      if (card.classList.contains('hi-card--active')) return;
+      STACK_CLASSES.forEach(function (cls) { card.classList.remove(cls); });
+      var dist = mod(i - goingTo, total);
+      card.classList.add(
+        dist === 0 ? 'hi-card--behind-1' :
+        dist === 1 ? 'hi-card--behind-2' :
+                     'hi-card--hidden'
+      );
+    });
   }
 
   var animating = false;
@@ -372,7 +388,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
     var dx = e.clientX - msx;
     if (Math.abs(dx) > 4) didDrag = true;
     var card = getActiveCard();
-    if (card) applyDrag(card, dx);
+    if (card) { applyDrag(card, dx); applyPreview(dx); }
   }, false);
   document.addEventListener('mouseup', function (e) {
     if (!dragging) return;
@@ -402,7 +418,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
     touchLocked = true;
     if (Math.abs(dx) > 4) didDrag = true;
     var card = getActiveCard();
-    if (card) applyDrag(card, dx);
+    if (card) { applyDrag(card, dx); applyPreview(dx); }
   }, { passive: true });
   stack.addEventListener('touchend', function (e) {
     var dx = e.changedTouches[0].clientX - tsx;


### PR DESCRIPTION
## Summary
- During a drag, the card showing behind was always `current+1` (next) regardless of which direction you were swiping
- If you dragged right (going back to previous), the wrong card was peeking — caused a confusing jump on release
- Fix: `applyPreview(dx)` fires during mousemove/touchmove and rearranges `behind-1`/`behind-2` to match where the drag is headed (threshold: 20px committed travel)
- On snap-back, `updateStack()` restores the default order

## Test plan
- [ ] Drag right — previous card peeks behind
- [ ] Drag left — next card peeks behind
- [ ] Release without threshold — snaps back, order restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)