### PR TITLE
Hi page: wire Strava card into hi.md (#43)

### DIFF
--- a/hi.md
+++ b/hi.md
@@ -367,6 +367,10 @@ html[data-theme="dark"] p { color: #e8e8e8; }
       </div>
     </div>
 
+    <div class="hi-card" id="hi-card-4">
+      {% include strava.html %}
+    </div>
+
   </div>
 
 </div>


### PR DESCRIPTION
## Summary
- PR #42 added `_includes/strava.html` but forgot to add the card div to `hi.md` — the Strava card never appeared in the stack
- Adds `<div class="hi-card" id="hi-card-4">{% include strava.html %}</div>` after the music card

## Test plan
- [ ] Navigate to /hi/ and verify 5 cards load
- [ ] Advance to last card and confirm Strava map renders with route line and footer stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)