### PR TITLE
CI: use PAT for Strava Action push to bypass branch protection

### DIFF
--- a/.github/workflows/strava-update.yml
+++ b/.github/workflows/strava-update.yml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.STRAVA_PUSH_TOKEN }}
 
       - name: Fetch latest ride and write _data/strava.json
         env:


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` cannot bypass the `main-protection` ruleset even with the Write role added to the bypass list — it's a bot token, not a user
- Switches `actions/checkout@v4` to use `STRAVA_PUSH_TOKEN` (fine-grained PAT, Contents: read/write on this repo), which authenticates as the repo owner and is allowed through the ruleset

## Test plan
- [ ] Merge and run the workflow via workflow_dispatch
- [ ] Confirm the Action pushes `_data/strava.json` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)