### PR TITLE
Hi page: Strava card with real Leaflet map

### DIFF
--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -1,4 +1,5 @@
 {% assign ride = site.data.strava %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <div class="strava-card">
   <div class="strava-card-header">
     <svg class="strava-icon" width="16" height="16" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -8,7 +9,7 @@
     <span class="strava-card-label">Latest Ride</span>
   </div>
   <div class="strava-map-wrap">
-    <canvas class="strava-map-canvas" id="strava-map"></canvas>
+    <div class="strava-map-div" id="strava-map"></div>
     {% if ride.name == "" %}
     <div class="strava-map-empty">No ride data yet</div>
     {% endif %}
@@ -29,7 +30,7 @@
   }
   .strava-card-header {
     flex: 0 0 auto;
-    padding: 10px 14px 10px;
+    padding: 10px 14px;
     border-bottom: 1px solid rgba(0,0,0,0.1);
     display: flex; align-items: center; gap: 7px;
   }
@@ -43,16 +44,15 @@
   .strava-map-wrap {
     flex: 1; min-height: 0;
     position: relative;
-    background: #1a2030;
   }
-  .strava-map-canvas {
+  .strava-map-div {
     width: 100%; height: 100%;
-    display: block;
   }
   .strava-map-empty {
     position: absolute; inset: 0;
     display: flex; align-items: center; justify-content: center;
     color: #556; font-size: 0.85em;
+    background: #1a2030;
   }
   .strava-card-footer {
     flex: 0 0 auto;
@@ -66,6 +66,8 @@
   .strava-ride-meta {
     font-size: 0.82em; color: #888;
   }
+  .strava-map-div .leaflet-control-zoom,
+  .strava-map-div .leaflet-control-attribution { display: none !important; }
   @media (prefers-color-scheme: dark) {
     .strava-card-header { border-bottom-color: rgba(255,255,255,0.1); }
     .strava-card-footer { border-top-color: rgba(255,255,255,0.1); }
@@ -78,6 +80,7 @@
   :root[data-theme="dark"] .strava-ride-meta { color: #777; }
 </style>
 
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 (function () {
   var raw = document.getElementById('strava-data');
@@ -86,7 +89,6 @@
   try { ride = JSON.parse(raw.textContent); } catch (e) { return; }
   if (!ride || !ride.name) return;
 
-  // Format meta line
   var meta = document.getElementById('strava-meta');
   if (meta) {
     var mi = (ride.distance / 1609.34).toFixed(1) + ' mi';
@@ -98,66 +100,7 @@
     meta.textContent = [date, mi, time].filter(Boolean).join(' · ');
   }
 
-  // Draw route on canvas
   if (!ride.map_polyline) return;
-  var canvas = document.getElementById('strava-map');
-  if (!canvas) return;
-
-  function drawMap() {
-    var pts = decodePolyline(ride.map_polyline);
-    if (pts.length < 2) return;
-    var dpr = window.devicePixelRatio || 1;
-    var w = canvas.offsetWidth, h = canvas.offsetHeight;
-    canvas.width = w * dpr; canvas.height = h * dpr;
-    var ctx = canvas.getContext('2d');
-    ctx.scale(dpr, dpr);
-
-    // Find bounds
-    var minLat = Infinity, maxLat = -Infinity, minLng = Infinity, maxLng = -Infinity;
-    pts.forEach(function (p) {
-      if (p[0] < minLat) minLat = p[0]; if (p[0] > maxLat) maxLat = p[0];
-      if (p[1] < minLng) minLng = p[1]; if (p[1] > maxLng) maxLng = p[1];
-    });
-
-    var pad = Math.min(w, h) * 0.1;
-    var latRange = maxLat - minLat || 0.001;
-    var lngRange = maxLng - minLng || 0.001;
-    var sx = (w - pad * 2) / lngRange;
-    var sy = (h - pad * 2) / latRange;
-    var sc = Math.min(sx, sy);
-    var ox = (w - lngRange * sc) / 2;
-    var oy = (h - latRange * sc) / 2;
-
-    function px(p) { return ox + (p[1] - minLng) * sc; }
-    function py(p) { return h - (oy + (p[0] - minLat) * sc); }
-
-    // Subtle grid-less background already handled by CSS
-    // Draw shadow glow
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(px(pts[0]), py(pts[0]));
-    for (var i = 1; i < pts.length; i++) ctx.lineTo(px(pts[i]), py(pts[i]));
-    ctx.strokeStyle = 'rgba(252, 76, 2, 0.25)';
-    ctx.lineWidth = 8;
-    ctx.lineJoin = 'round'; ctx.lineCap = 'round';
-    ctx.stroke();
-    ctx.restore();
-
-    // Draw route
-    ctx.beginPath();
-    ctx.moveTo(px(pts[0]), py(pts[0]));
-    for (var j = 1; j < pts.length; j++) ctx.lineTo(px(pts[j]), py(pts[j]));
-    ctx.strokeStyle = '#FC4C02';
-    ctx.lineWidth = 2.5;
-    ctx.lineJoin = 'round'; ctx.lineCap = 'round';
-    ctx.stroke();
-
-    // Start dot
-    ctx.beginPath();
-    ctx.arc(px(pts[0]), py(pts[0]), 4, 0, Math.PI * 2);
-    ctx.fillStyle = '#FC4C02';
-    ctx.fill();
-  }
 
   function decodePolyline(enc) {
     var pts = [], i = 0, lat = 0, lng = 0;
@@ -173,11 +116,43 @@
     return pts;
   }
 
-  if (canvas.offsetWidth > 0) {
-    drawMap();
+  function initMap() {
+    var pts = decodePolyline(ride.map_polyline);
+    if (pts.length < 2) return;
+
+    var map = L.map('strava-map', {
+      zoomControl: false,
+      dragging: false,
+      touchZoom: false,
+      doubleClickZoom: false,
+      scrollWheelZoom: false,
+      boxZoom: false,
+      keyboard: false,
+      attributionControl: false,
+    });
+
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_matter_nolabels/{z}/{x}/{y}{r}.png', {
+      subdomains: 'abcd',
+      maxZoom: 19,
+    }).addTo(map);
+
+    var route = L.polyline(pts, { color: '#FC4C02', weight: 3, opacity: 1 }).addTo(map);
+    map.fitBounds(route.getBounds(), { padding: [24, 24] });
+
+    L.circleMarker(pts[0], {
+      radius: 5, fillColor: '#FC4C02',
+      color: '#fff', weight: 2, fillOpacity: 1,
+    }).addTo(map);
+  }
+
+  var mapDiv = document.getElementById('strava-map');
+  if (mapDiv.offsetHeight > 0) {
+    initMap();
   } else {
-    var ro = new ResizeObserver(function () { drawMap(); ro.disconnect(); });
-    ro.observe(canvas);
+    var ro = new ResizeObserver(function () {
+      if (mapDiv.offsetHeight > 0) { ro.disconnect(); initMap(); }
+    });
+    ro.observe(mapDiv);
   }
 })();
 </script>


### PR DESCRIPTION
## Summary
- Replaces plain canvas route drawing with Leaflet + CartoDB dark_matter_nolabels tiles
- Real street map background with Strava orange route overlay and start dot
- Non-interactive (no zoom/pan/scroll controls) — purely visual widget
- Initializes via ResizeObserver so the map renders correctly when the card becomes active

## Test plan
- [ ] Navigate to /hi/ → advance to Strava card → confirm dark map tiles + route render
- [ ] Confirm footer shows real ride name, distance, and time

🤖 Generated with [Claude Code](https://claude.com/claude-code)