### PR TITLE
Hi page: switch Strava map to OpenStreetMap tiles

### DIFF
--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -131,8 +131,8 @@
       attributionControl: false,
     });
 
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_matter_nolabels/{z}/{x}/{y}{r}.png', {
-      subdomains: 'abcd',
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      subdomains: 'abc',
       maxZoom: 19,
     }).addTo(map);
 


### PR DESCRIPTION
## Summary
- CartoDB `dark_matter_nolabels` tiles were failing to load (returning broken images) on both localhost and production
- Switch to `tile.openstreetmap.org` — universally available, no API key required

🤖 Generated with [Claude Code](https://claude.com/claude-code)