### PR TITLE
Hi page: real Strava logo + OSM map tiles

### DIFF
--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -2,9 +2,9 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <div class="strava-card">
   <div class="strava-card-header">
-    <svg class="strava-icon" width="16" height="16" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M27.6 46.8L18 28.8H27.6L37.2 46.8Z" fill="#FC4C02"/>
-      <path d="M46.8 46.8L37.2 28.8H46.8L56.4 46.8Z" fill="#FC4C02" opacity="0.6"/>
+    <svg class="strava-icon" width="14" height="20" viewBox="0 0 42 59" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M29.2706 43.5683L24.1528 33.4854L16.5283 33.4982L29.2706 58.4349L41.9999 33.4854H34.3754L29.2706 43.5683Z" fill="#FC5200"/>
+      <path d="M17.1812 19.9467L24.1529 33.4852H34.3755L17.1812 0L0 33.4852H10.2356L17.1812 19.9467Z" fill="#FC5200"/>
     </svg>
     <span class="strava-card-label">Latest Ride</span>
   </div>


### PR DESCRIPTION
## Summary
- Replaces hand-approximated Strava icon with the actual brand SVG (two-path mark)
- OSM map tiles confirmed rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)