### PR TITLE
Hi page: dark mode Strava map tile inversion

### DIFF
--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -69,6 +69,10 @@
   .strava-map-div .leaflet-control-zoom,
   .strava-map-div .leaflet-control-attribution { display: none !important; }
   @media (prefers-color-scheme: dark) {
+    .strava-map-div .leaflet-tile-pane { filter: invert(1) hue-rotate(180deg); }
+  }
+  :root[data-theme="dark"] .strava-map-div .leaflet-tile-pane { filter: invert(1) hue-rotate(180deg); }
+  @media (prefers-color-scheme: dark) {
     .strava-card-header { border-bottom-color: rgba(255,255,255,0.1); }
     .strava-card-footer { border-top-color: rgba(255,255,255,0.1); }
     .strava-card-label { color: #bbb; }


### PR DESCRIPTION
## Summary
- In dark mode, inverts only the Leaflet tile pane (`filter: invert(1) hue-rotate(180deg)`)
- Route overlay stays in the separate `.leaflet-overlay-pane` so the orange line is unaffected
- Covers both `prefers-color-scheme: dark` and `data-theme="dark"` toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)