### PR TITLE
Hi page: add subtitle below heading

### DIFF
--- a/hi.md
+++ b/hi.md
@@ -314,6 +314,8 @@ html[data-theme="dark"] p { color: #e8e8e8; }
 
 # Hello from Brooklyn, NY
 
+<p style="font-family: Georgia, serif; font-style: italic; opacity: 0.5; margin-top: -0.6em; margin-bottom: 1.5em; font-size: 1.05em;">A snapshot of my life outside of work</p>
+
 <div class="hi-stack-outer">
 
   <div class="hi-stack" id="hi-stack">


### PR DESCRIPTION
## Summary
- Adds *"A snapshot of my life outside of work"* in serif italic below the "Hello from Brooklyn, NY" heading
- 50% opacity so it reads at half the title's color in both light and dark mode without needing separate color overrides
- Gives visitors context for the card stack, pairing against the Info page

🤖 Generated with [Claude Code](https://claude.com/claude-code)