### PR TITLE
Info page: Now bolt icon + remove pardon link

### DIFF
--- a/info.md
+++ b/info.md
@@ -45,11 +45,15 @@ I love working with teams that value asking questions. _Why are we creating a gi
       <i class="fas fa-file-pdf" style="font-size:1.5em;"></i>
       <span style="font-size:0.78em;">Résumé</span>
     </a>
+    <a href="/hi/" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">
+      <i class="fas fa-bolt" style="font-size:1.5em;"></i>
+      <span style="font-size:0.78em;">Now</span>
+    </a>
   </div>
 </div>
 
 <div class="fade-in-block" style="animation-delay:1.15s; margin: 1.8em 0 1.8em; opacity: 0.75;" markdown="1">
-  <p style="margin: 0; font-size: 0.9em; font-style: italic; font-family: Georgia, serif; line-height: 1.6; color: inherit;">Pardon my portfolio's rough edges. I'm updating on a near-daily basis, adding and revising case studies, and exploring Claude Code for animation and other frontend enhancements. Enjoy the show. Running on Github Pages, Jekyll, and iterating off of <a href="https://mmistakes.github.io/minimal-mistakes/" style="color:inherit;">Minimal Mistakes</a> theme. See what I'm up to lately at <a href="https://hi.justinpocta.com" style="color:inherit;">hi.justinpocta.com</a>.</p>
+  <p style="margin: 0; font-size: 0.9em; font-style: italic; font-family: Georgia, serif; line-height: 1.6; color: inherit;">Pardon my portfolio's rough edges. I'm updating on a near-daily basis, adding and revising case studies, and exploring Claude Code for animation and other frontend enhancements. Enjoy the show. Running on Github Pages, Jekyll, and iterating off of <a href="https://mmistakes.github.io/minimal-mistakes/" style="color:inherit;">Minimal Mistakes</a> theme.</p>
 </div>
 
 <div style="clear: both; padding-bottom: 40px;"></div>


### PR DESCRIPTION
## Summary
- Adds bolt icon + "Now" link to the Get in Touch section, pointing to /hi/
- Removes the "See what I'm up to lately at hi.justinpocta.com" sentence from the pardon paragraph (now covered by the icon link above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)