### PR TITLE
Fix tile CSS animations not playing in desktop Safari

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -251,13 +251,13 @@
     if (active) _applyTileBg(active);
   }
 
-  // ── IntersectionObserver for mobile greyscale reveal ─────────────
+  // ── IntersectionObserver: greyscale reveal + Safari animation restart ──
   (function() {
-    if (!window.matchMedia('(hover: none)').matches) return;
+    var isTouchOnly = !window.matchMedia('(hover: hover)').matches;
     var tiles = document.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
-        entry.target.classList.toggle('in-view', entry.isIntersecting);
+        if (isTouchOnly) entry.target.classList.toggle('in-view', entry.isIntersecting);
         if (entry.isIntersecting) {
           // Safari suspends @keyframes on off-screen scroll-container elements;
           // restart CSS animations from the beginning when the tile scrolls into view.


### PR DESCRIPTION
## Summary
Safari throttles `@keyframes` animations on elements that are off-screen inside a scroll container. The fix (reset `animationName` to `none` then back to `''` on IntersectionObserver entry) already existed but was gated behind `(hover: none)`, so it never ran on desktop Safari.

This removes the guard so the animation restart fires on all devices whenever a tile scrolls into view. The touch-only `in-view` greyscale class toggle is preserved.

## Why the recruiting tile worked
It uses JS `setTimeout`-driven transitions, not CSS `@keyframes` — unaffected by Safari's throttling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)