### PR TITLE
Remove animation restart hack; fix Get in Touch 3+2 on mobile

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -251,22 +251,14 @@
     if (active) _applyTileBg(active);
   }
 
-  // ── IntersectionObserver: greyscale reveal + Safari animation restart ──
+  // ── IntersectionObserver: greyscale reveal on touch devices ──
   (function() {
     var isTouchOnly = !window.matchMedia('(hover: hover)').matches;
+    if (!isTouchOnly) return;
     var tiles = document.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
-        if (isTouchOnly) entry.target.classList.toggle('in-view', entry.isIntersecting);
-        if (entry.isIntersecting) {
-          // Safari suspends @keyframes on off-screen scroll-container elements;
-          // restart CSS animations from the beginning when the tile scrolls into view.
-          entry.target.querySelectorAll('.css-anim *').forEach(function(el) {
-            el.style.animationName = 'none';
-            void el.offsetWidth; // force reflow to flush the removal
-            el.style.animationName = '';
-          });
-        }
+        entry.target.classList.toggle('in-view', entry.isIntersecting);
       });
     }, { threshold: 0.5 });
     tiles.forEach(function(tile) { observer.observe(tile); });

--- a/info.md
+++ b/info.md
@@ -26,9 +26,16 @@ I love working with teams that value asking questions. _Why are we creating a gi
 
 </div>
 
+<style>
+@media (max-width: 600px) {
+  .gi-links { flex-wrap: wrap !important; gap: 24px 5% !important; }
+  .gi-links a { flex: 0 0 28%; }
+}
+</style>
+
 <div class="fade-in-block" style="animation-delay:1.05s; border: 2px solid #D4B870; border-radius: 6px; padding: 26px 32px 32px; margin: 1.5em 0 40px; text-align: center; box-sizing: border-box; overflow: hidden;">
   <p style="margin: 0 0 28px; font-weight: 400; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.1em; color: #999;">Get in Touch</p>
-  <div style="display: flex; gap: 48px; justify-content: center;">
+  <div class="gi-links" style="display: flex; gap: 48px; justify-content: center;">
     <a href="mailto:howdy@justinpocta.com?subject=Hello" style="display:flex; flex-direction:column; align-items:center; gap:10px; text-decoration:none; color:#B8963A;">
       <i class="fas fa-envelope" style="font-size:1.5em;"></i>
       <span style="font-size:0.78em;">Email</span>


### PR DESCRIPTION
## Summary
- **Animation**: Removed the Safari @keyframes restart hack from the IntersectionObserver. All tile animations are `infinite` loops so Safari resuming mid-loop is fine. IntersectionObserver kept for touch-device greyscale reveal.
- **Info mobile layout**: Get in Touch 5 icons now wrap 3 on top row + 2 centered below on screens ≤ 600px using `flex-wrap` with a `28%` flex-basis per icon and a `5%` column gap.

## Test plan
- [ ] Desktop: all 5 icons in one row on info page
- [ ] Mobile (≤ 600px): Email/LinkedIn/GitHub on row 1, Résumé/Now centered on row 2
- [ ] Tile animations play on Safari desktop without needing to scroll away and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)