### PR TITLE
Add Duolingo card to hi/now stack

### DIFF
--- a/.github/workflows/duolingo-update.yml
+++ b/.github/workflows/duolingo-update.yml
@@ -1,0 +1,67 @@
+name: Update Duolingo Data
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.STRAVA_PUSH_TOKEN }}
+
+      - name: Fetch Duolingo data and write _data/duolingo.json
+        run: |
+          python3 << 'PYEOF'
+          import json, urllib.request, datetime
+
+          url = 'https://www.duolingo.com/2017-06-30/users?username=texnology84&fields=username,streak,picture,hasPlus,creationDate,learningLanguage,courses'
+          req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+          with urllib.request.urlopen(req) as r:
+            data = json.load(r)
+
+          users = data.get('users', [])
+          if not users:
+            print('No user data returned, keeping existing file')
+            exit(0)
+
+          user = users[0]
+          creation_ts = user.get('creationDate', 0)
+          member_since = datetime.datetime.utcfromtimestamp(creation_ts).strftime('%b %Y') if creation_ts else ''
+
+          courses = user.get('courses', [])
+          fr_course = next((c for c in courses if c.get('learningLanguage') == 'fr'), None)
+          french_level = fr_course.get('level', 0) if fr_course else 0
+
+          out = {
+            'username': user.get('username', 'texnology84'),
+            'streak': user.get('streak', 0),
+            'picture': user.get('picture', ''),
+            'hasPlus': user.get('hasPlus', False),
+            'member_since': member_since,
+            'learningLanguage': user.get('learningLanguage', 'fr'),
+            'french_level': french_level,
+            'updated_at': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+          }
+
+          with open('_data/duolingo.json', 'w') as f:
+            json.dump(out, f, indent=2)
+          print(f"Streak: {out['streak']} | Super: {out['hasPlus']} | Since: {out['member_since']}")
+          PYEOF
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add _data/duolingo.json
+          if git diff --staged --quiet; then
+            echo "No changes"
+          else
+            git commit -m "Auto-update Duolingo data [skip ci]"
+            git push
+          fi

--- a/_data/duolingo.json
+++ b/_data/duolingo.json
@@ -1,0 +1,10 @@
+{
+  "username": "texnology84",
+  "streak": 155,
+  "picture": "",
+  "hasPlus": true,
+  "member_since": "Nov 2012",
+  "learningLanguage": "fr",
+  "french_level": 9,
+  "updated_at": "2026-07-26T00:00:00Z"
+}

--- a/_includes/duolingo.html
+++ b/_includes/duolingo.html
@@ -3,7 +3,6 @@
   <div class="duo-card-header">
     <span class="duo-owl">&#x1F989;</span>
     <span class="duo-card-label">Duolingo</span>
-    {% if duo.hasPlus %}<span class="duo-super-pill">Super</span>{% endif %}
   </div>
   <div class="duo-card-body">
     <div class="duo-profile">
@@ -14,19 +13,27 @@
       {% endif %}
       <div class="duo-username">{{ duo.username }}</div>
       <div class="duo-since">Member since {{ duo.member_since }}</div>
+      {% if duo.hasPlus %}<span class="duo-super-pill">Super</span>{% endif %}
     </div>
-    <div class="duo-divider"></div>
-    <div class="duo-language">
-      <span class="duo-flag">&#x1F1EB;&#x1F1F7;</span>
-      <div class="duo-lang-info">
-        <span class="duo-lang-text">Fran&ccedil;ais</span>
-        <span class="duo-lang-level">Level {{ duo.french_level }}</span>
+    <div class="duo-rule"></div>
+    <div class="duo-stats">
+      <div class="duo-stat">
+        <span class="duo-stat-label">Level</span>
+        <span class="duo-stat-num">{{ duo.french_level }}</span>
+        <span class="duo-stat-sub">&nbsp;</span>
       </div>
-    </div>
-    <div class="duo-divider"></div>
-    <div class="duo-streak">
-      <div class="duo-streak-num">{{ duo.streak }}</div>
-      <div class="duo-streak-label">&#x1F525;&nbsp;day streak</div>
+      <div class="duo-stat-vr"></div>
+      <div class="duo-stat">
+        <span class="duo-stat-label">Language</span>
+        <span class="duo-stat-flag">&#x1F1EB;&#x1F1F7;</span>
+        <span class="duo-stat-sub">Fran&ccedil;ais</span>
+      </div>
+      <div class="duo-stat-vr"></div>
+      <div class="duo-stat">
+        <span class="duo-stat-label">Day Streak</span>
+        <span class="duo-stat-num">{{ duo.streak }}</span>
+        <span class="duo-stat-sub">&nbsp;</span>
+      </div>
     </div>
   </div>
 </div>
@@ -64,13 +71,15 @@
   .duo-card-body {
     flex: 1; min-height: 0;
     display: flex; flex-direction: column;
-    align-items: center; justify-content: space-evenly;
-    padding: 20px 16px;
+    align-items: stretch;
+    justify-content: space-evenly;
+    padding: 24px 0 20px;
     text-align: center;
   }
   .duo-profile {
     display: flex; flex-direction: column;
     align-items: center; gap: 6px;
+    padding: 0 16px;
   }
   .duo-avatar {
     width: 72px; height: 72px;
@@ -92,47 +101,65 @@
     font-size: 0.78em;
     color: #888;
   }
-  .duo-divider {
-    width: 40px; height: 1px;
-    background: rgba(0,0,0,0.1);
-    border-radius: 1px;
+  .duo-rule {
+    height: 1px;
+    background: rgba(0,0,0,0.08);
+    margin: 0 16px;
   }
-  .duo-language {
-    display: flex; align-items: center; gap: 10px;
+  .duo-stats {
+    display: flex;
+    align-items: stretch;
   }
-  .duo-flag { font-size: 1.5em; line-height: 1; }
-  .duo-lang-info { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; }
-  .duo-lang-text { font-weight: 600; font-size: 1.0em; line-height: 1.2; }
-  .duo-lang-level { font-size: 0.75em; color: #888; }
-  .duo-streak {
+  .duo-stat {
+    flex: 1;
     display: flex; flex-direction: column;
-    align-items: center; gap: 4px;
+    align-items: center; justify-content: center;
+    gap: 6px;
+    padding: 16px 8px;
   }
-  .duo-streak-num {
-    font-size: 3.2em;
+  .duo-stat-vr {
+    width: 1px;
+    background: rgba(0,0,0,0.08);
+    align-self: stretch;
+    margin: 12px 0;
+  }
+  .duo-stat-label {
+    font-size: 0.62em;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: #aaa;
+  }
+  .duo-stat-flag {
+    font-size: 2.4em;
+    line-height: 1;
+  }
+  .duo-stat-num {
+    font-size: 2.6em;
     font-weight: 900;
     line-height: 1;
-    color: #FF9600;
     letter-spacing: -0.02em;
   }
-  .duo-streak-label {
-    font-size: 0.82em;
+.duo-stat-sub {
+    font-size: 0.72em;
     color: #888;
+    line-height: 1;
   }
   @media (prefers-color-scheme: dark) {
     .duo-card-header { border-bottom-color: rgba(255,255,255,0.1); }
     .duo-card-label { color: #bbb; }
     .duo-avatar-placeholder { background: #333; }
     .duo-since { color: #666; }
-    .duo-divider { background: rgba(255,255,255,0.1); }
-    .duo-lang-level { color: #666; }
-    .duo-streak-label { color: #666; }
+    .duo-rule { background: rgba(255,255,255,0.08); }
+    .duo-stat-vr { background: rgba(255,255,255,0.08); }
+    .duo-stat-label { color: #555; }
+    .duo-stat-sub { color: #666; }
   }
   :root[data-theme="dark"] .duo-card-header { border-bottom-color: rgba(255,255,255,0.1); }
   :root[data-theme="dark"] .duo-card-label { color: #bbb; }
   :root[data-theme="dark"] .duo-avatar-placeholder { background: #333; }
   :root[data-theme="dark"] .duo-since { color: #666; }
-  :root[data-theme="dark"] .duo-divider { background: rgba(255,255,255,0.1); }
-  :root[data-theme="dark"] .duo-lang-level { color: #666; }
-  :root[data-theme="dark"] .duo-streak-label { color: #666; }
+  :root[data-theme="dark"] .duo-rule { background: rgba(255,255,255,0.08); }
+  :root[data-theme="dark"] .duo-stat-vr { background: rgba(255,255,255,0.08); }
+  :root[data-theme="dark"] .duo-stat-label { color: #555; }
+  :root[data-theme="dark"] .duo-stat-sub { color: #666; }
 </style>

--- a/_includes/duolingo.html
+++ b/_includes/duolingo.html
@@ -1,0 +1,138 @@
+{% assign duo = site.data.duolingo %}
+<div class="duo-card">
+  <div class="duo-card-header">
+    <span class="duo-owl">&#x1F989;</span>
+    <span class="duo-card-label">Duolingo</span>
+    {% if duo.hasPlus %}<span class="duo-super-pill">Super</span>{% endif %}
+  </div>
+  <div class="duo-card-body">
+    <div class="duo-profile">
+      {% if duo.picture and duo.picture != "" %}
+      <img class="duo-avatar" src="{{ duo.picture }}" alt="{{ duo.username }}">
+      {% else %}
+      <div class="duo-avatar-placeholder"></div>
+      {% endif %}
+      <div class="duo-username">{{ duo.username }}</div>
+      <div class="duo-since">Member since {{ duo.member_since }}</div>
+    </div>
+    <div class="duo-divider"></div>
+    <div class="duo-language">
+      <span class="duo-flag">&#x1F1EB;&#x1F1F7;</span>
+      <div class="duo-lang-info">
+        <span class="duo-lang-text">Fran&ccedil;ais</span>
+        <span class="duo-lang-level">Level {{ duo.french_level }}</span>
+      </div>
+    </div>
+    <div class="duo-divider"></div>
+    <div class="duo-streak">
+      <div class="duo-streak-num">{{ duo.streak }}</div>
+      <div class="duo-streak-label">&#x1F525;&nbsp;day streak</div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .duo-card {
+    width: 100%; height: 100%;
+    display: flex; flex-direction: column;
+    overflow: hidden; border-radius: 10px;
+  }
+  .duo-card-header {
+    flex: 0 0 auto;
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+    display: flex; align-items: center; gap: 7px;
+  }
+  .duo-owl { font-size: 1.05em; line-height: 1; }
+  .duo-card-label {
+    font-size: 0.72em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #555;
+    flex: 1;
+  }
+  .duo-super-pill {
+    font-size: 0.62em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    background: #58CC02;
+    color: #fff;
+    padding: 3px 9px;
+    border-radius: 99px;
+  }
+  .duo-card-body {
+    flex: 1; min-height: 0;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: space-evenly;
+    padding: 20px 16px;
+    text-align: center;
+  }
+  .duo-profile {
+    display: flex; flex-direction: column;
+    align-items: center; gap: 6px;
+  }
+  .duo-avatar {
+    width: 72px; height: 72px;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+  }
+  .duo-avatar-placeholder {
+    width: 72px; height: 72px;
+    border-radius: 50%;
+    background: #e8e8e8;
+  }
+  .duo-username {
+    font-weight: 700;
+    font-size: 1.0em;
+    line-height: 1.2;
+  }
+  .duo-since {
+    font-size: 0.78em;
+    color: #888;
+  }
+  .duo-divider {
+    width: 40px; height: 1px;
+    background: rgba(0,0,0,0.1);
+    border-radius: 1px;
+  }
+  .duo-language {
+    display: flex; align-items: center; gap: 10px;
+  }
+  .duo-flag { font-size: 1.5em; line-height: 1; }
+  .duo-lang-info { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; }
+  .duo-lang-text { font-weight: 600; font-size: 1.0em; line-height: 1.2; }
+  .duo-lang-level { font-size: 0.75em; color: #888; }
+  .duo-streak {
+    display: flex; flex-direction: column;
+    align-items: center; gap: 4px;
+  }
+  .duo-streak-num {
+    font-size: 3.2em;
+    font-weight: 900;
+    line-height: 1;
+    color: #FF9600;
+    letter-spacing: -0.02em;
+  }
+  .duo-streak-label {
+    font-size: 0.82em;
+    color: #888;
+  }
+  @media (prefers-color-scheme: dark) {
+    .duo-card-header { border-bottom-color: rgba(255,255,255,0.1); }
+    .duo-card-label { color: #bbb; }
+    .duo-avatar-placeholder { background: #333; }
+    .duo-since { color: #666; }
+    .duo-divider { background: rgba(255,255,255,0.1); }
+    .duo-lang-level { color: #666; }
+    .duo-streak-label { color: #666; }
+  }
+  :root[data-theme="dark"] .duo-card-header { border-bottom-color: rgba(255,255,255,0.1); }
+  :root[data-theme="dark"] .duo-card-label { color: #bbb; }
+  :root[data-theme="dark"] .duo-avatar-placeholder { background: #333; }
+  :root[data-theme="dark"] .duo-since { color: #666; }
+  :root[data-theme="dark"] .duo-divider { background: rgba(255,255,255,0.1); }
+  :root[data-theme="dark"] .duo-lang-level { color: #666; }
+  :root[data-theme="dark"] .duo-streak-label { color: #666; }
+</style>

--- a/hi.md
+++ b/hi.md
@@ -376,6 +376,10 @@ html[data-theme="dark"] p { color: #e8e8e8; }
       {% include strava.html %}
     </div>
 
+    <div class="hi-card" id="hi-card-5">
+      {% include duolingo.html %}
+    </div>
+
   </div>
 
 </div>

--- a/now.md
+++ b/now.md
@@ -376,6 +376,10 @@ html[data-theme="dark"] p { color: #e8e8e8; }
       {% include strava.html %}
     </div>
 
+    <div class="hi-card" id="hi-card-5">
+      {% include duolingo.html %}
+    </div>
+
   </div>
 
 </div>


### PR DESCRIPTION
## Summary
- New `_includes/duolingo.html` card: 🦉 header, SUPER badge, avatar placeholder, username, member since date, 🇫🇷 Français + Level 9, and big orange streak number
- Added as card #5 in both `hi.md` and `now.md`
- `_data/duolingo.json` seeded with current known values (streak 155, level 9, Nov 2012)
- `.github/workflows/duolingo-update.yml` runs daily at 8am UTC — fetches from Duolingo's public API server-side (no auth/secrets needed), commits updated JSON including streak, level, avatar URL, and Super status

## Notes
- Avatar will appear once the Action runs and populates the picture URL
- Reuses existing `STRAVA_PUSH_TOKEN` secret for the commit push

## Test plan
- [ ] Card #5 appears in stack on `/hi/` and `/now/`
- [ ] SUPER badge visible, streak shows 155, Level 9 under Français
- [ ] Run Action manually via workflow_dispatch to verify data fetch works

🤖 Generated with [Claude Code](https://claude.com/claude-code)