### PR TITLE
Hi page: fix Flickr handle color (theme override)

### DIFF
--- a/_includes/flickr.html
+++ b/_includes/flickr.html
@@ -72,10 +72,11 @@
     font-weight: 700;
     font-size: 0.95rem;
   }
-  .flickr-handle {
+  .flickr-handle,
+  .flickr-handle:visited {
     font-weight: 400;
     font-size: 0.95rem;
-    color: #fff;
+    color: #fff !important;
     text-decoration: none;
   }
   .flickr-handle:hover {


### PR DESCRIPTION
## Summary

The theme's global link color (`#B8963A` gold) was winning the cascade over `.flickr-handle { color: #fff }` since it's an `<a>` element. Added `!important` and a `:visited` selector to lock it white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)