### PR TITLE
Home: restore Safari tile animation restart

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -251,14 +251,22 @@
     if (active) _applyTileBg(active);
   }
 
-  // ── IntersectionObserver: greyscale reveal on touch devices ──
+  // ── IntersectionObserver: greyscale reveal on touch + Safari animation restart ──
   (function() {
     var isTouchOnly = !window.matchMedia('(hover: hover)').matches;
-    if (!isTouchOnly) return;
     var tiles = document.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
-        entry.target.classList.toggle('in-view', entry.isIntersecting);
+        if (isTouchOnly) entry.target.classList.toggle('in-view', entry.isIntersecting);
+        if (entry.isIntersecting) {
+          // Safari suspends @keyframes on off-screen scroll-container elements;
+          // force-restart by toggling animationName off/on with a reflow in between.
+          entry.target.querySelectorAll('.css-anim *').forEach(function(el) {
+            el.style.animationName = 'none';
+            void el.offsetWidth;
+            el.style.animationName = '';
+          });
+        }
       });
     }, { threshold: 0.5 });
     tiles.forEach(function(tile) { observer.observe(tile); });


### PR DESCRIPTION
## Summary

Safari suspends `@keyframes` animations on elements inside an `overflow: scroll` container when those elements are scrolled off-screen. PR #57 removed the `IntersectionObserver` restart hack with the reasoning that infinite animations auto-resume mid-loop — they don't in Safari.

Restoring the original fix: when a tile scrolls into view, toggle `animationName` off → reflow → back on, which forces Safari to restart the animation. The touch-only `in-view` class toggle for greyscale reveal is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)