### PR TITLE
Home: fix Safari CSS tile animations not restarting on scroll

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -251,22 +251,14 @@
     if (active) _applyTileBg(active);
   }
 
-  // ── IntersectionObserver: greyscale reveal on touch + Safari animation restart ──
+  // ── IntersectionObserver: greyscale reveal on touch devices ──
   (function() {
     var isTouchOnly = !window.matchMedia('(hover: hover)').matches;
+    if (!isTouchOnly) return;
     var tiles = document.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
-        if (isTouchOnly) entry.target.classList.toggle('in-view', entry.isIntersecting);
-        if (entry.isIntersecting) {
-          // Safari suspends @keyframes on off-screen scroll-container elements;
-          // force-restart by toggling animationName off/on with a reflow in between.
-          entry.target.querySelectorAll('.css-anim *').forEach(function(el) {
-            el.style.animationName = 'none';
-            void el.offsetWidth;
-            el.style.animationName = '';
-          });
-        }
+        entry.target.classList.toggle('in-view', entry.isIntersecting);
       });
     }, { threshold: 0.5 });
     tiles.forEach(function(tile) { observer.observe(tile); });
@@ -422,6 +414,7 @@
       return closest;
     }
 
+    var lastAnimIdx = -1;
     function update() {
       var idx = getCurrentIndex();
       btnLeft.classList.toggle('is-disabled', idx === 0);
@@ -435,6 +428,16 @@
         }
       });
       _applyTileBg(tiles[idx]);
+      // Safari suspends @keyframes on off-screen elements in scroll containers.
+      // When the active tile changes, force-restart its CSS animations via a
+      // class toggle that sets animation:none, a layout flush, then removes it.
+      if (idx !== lastAnimIdx) {
+        lastAnimIdx = idx;
+        var t = tiles[idx];
+        t.classList.add('anim-restart');
+        void t.offsetWidth;
+        requestAnimationFrame(function() { t.classList.remove('anim-restart'); });
+      }
     }
 
     tiles.forEach(function(tile) {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -727,6 +727,8 @@ a.hero-tile:hover { color: rgba(255,255,255,.75); text-decoration: none !importa
 @media (prefers-reduced-motion: reduce) {
     .css-anim * { animation: none !important; }
 }
+/* Safari animation restart: briefly applied by JS when active tile changes */
+.hero-tile.anim-restart .css-anim * { animation: none !important; }
 
 /* OG -- Wayfinding */
 .anim-og { width: 100%; height: 72px; display: flex; align-items: center; justify-content: center; }


### PR DESCRIPTION
## Summary

- Safari suspends `@keyframes` on elements inside `overflow: scroll` containers when they're scrolled off-screen, and does **not** auto-resume infinite animations when they scroll back
- Previous IntersectionObserver approach (PR #61) proved unreliable at `threshold: 0.5` during smooth scroll
- Fix: hook animation restart into `update()`, which already fires reliably on every active-tile change — adds `anim-restart` class, forces a layout flush via `offsetWidth`, then removes the class in a `requestAnimationFrame`
- Supporting CSS rule `.hero-tile.anim-restart .css-anim * { animation: none !important; }` forces the browser to re-evaluate the animation from frame 0

## Test plan
- [ ] Open home page in Safari, scroll the tile row — all tile animations (OG arrows/dots, Jobs float, Workflows connectors, Highlight spin, Transcreation morph) should play when each tile is active
- [ ] Verify the same in Chrome/Firefox (should be unaffected)
- [ ] Verify `prefers-reduced-motion` still suppresses all animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)