### PR TITLE
Home: fix Safari animation restart -- inline animationName per element

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -429,14 +429,15 @@
       });
       _applyTileBg(tiles[idx]);
       // Safari suspends @keyframes on off-screen elements in scroll containers.
-      // When the active tile changes, force-restart its CSS animations via a
-      // class toggle that sets animation:none, a layout flush, then removes it.
+      // Force-restart by setting animationName inline on each child, flushing
+      // the reflow per-element, then clearing the inline override.
       if (idx !== lastAnimIdx) {
         lastAnimIdx = idx;
-        var t = tiles[idx];
-        t.classList.add('anim-restart');
-        void t.offsetWidth;
-        requestAnimationFrame(function() { t.classList.remove('anim-restart'); });
+        tiles[idx].querySelectorAll('.css-anim *').forEach(function(el) {
+          el.style.animationName = 'none';
+          void el.offsetWidth;
+          el.style.animationName = '';
+        });
       }
     }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -727,8 +727,6 @@ a.hero-tile:hover { color: rgba(255,255,255,.75); text-decoration: none !importa
 @media (prefers-reduced-motion: reduce) {
     .css-anim * { animation: none !important; }
 }
-/* Safari animation restart: briefly applied by JS when active tile changes */
-.hero-tile.anim-restart .css-anim * { animation: none !important; }
 
 /* OG -- Wayfinding */
 .anim-og { width: 100%; height: 72px; display: flex; align-items: center; justify-content: center; }


### PR DESCRIPTION
## Summary

- The previous approach (PR #62) toggled an `anim-restart` class on the parent `.hero-tile` and called `void t.offsetWidth` on the parent. Safari doesn't reliably flush the animation subsystem this way.
- Reverts to the approach from PR #55 that actually worked: iterate `.css-anim *` children, set `el.style.animationName = 'none'` inline, call `void el.offsetWidth` per-element, then clear the inline override. This is synchronous and needs no `requestAnimationFrame`.
- Removes the now-unused `.hero-tile.anim-restart .css-anim *` CSS rule from `main.scss`.
- The restart is still hooked into `update()` (fired on every scroll event / active-tile change), not IntersectionObserver.

## Test plan
- [ ] Open home page in Safari, scroll tiles — all CSS animations (OG arrows/dots, Jobs float, Workflows connectors, Highlight spin, Transcreation morph) should play when each tile scrolls into view
- [ ] Chrome/Firefox unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)