### PR TITLE
Home: fix iOS CSS animation restart + trim mobile tile space

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -251,16 +251,28 @@
     if (active) _applyTileBg(active);
   }
 
-  // ── IntersectionObserver: greyscale reveal on touch devices ──
+  // ── IntersectionObserver: greyscale reveal + CSS animation restart ──
+  // root: the scroll row, so intersection is measured within the horizontal
+  // container (tiles off to the side = 0%, centered tile = ~100%).
+  // Animation restart fires here -- not in update() -- because IO fires after
+  // the tile is actually visible/settled, whereas scroll events fire mid-swipe
+  // when WebKit may still be animating the snap and ignores the restart.
   (function() {
+    var row = document.getElementById('tile-scroll-row');
+    if (!row) return;
     var isTouchOnly = !window.matchMedia('(hover: hover)').matches;
-    if (!isTouchOnly) return;
     var tiles = document.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
-        entry.target.classList.toggle('in-view', entry.isIntersecting);
+        if (isTouchOnly) entry.target.classList.toggle('in-view', entry.isIntersecting);
+        if (!entry.isIntersecting) return;
+        entry.target.querySelectorAll('.css-anim *').forEach(function(el) {
+          el.style.animationName = 'none';
+          void el.offsetWidth;
+          el.style.animationName = '';
+        });
       });
-    }, { threshold: 0.5 });
+    }, { root: row, threshold: 0.9 });
     tiles.forEach(function(tile) { observer.observe(tile); });
   })();
 
@@ -414,7 +426,6 @@
       return closest;
     }
 
-    var lastAnimIdx = -1;
     function update() {
       var idx = getCurrentIndex();
       btnLeft.classList.toggle('is-disabled', idx === 0);
@@ -428,17 +439,6 @@
         }
       });
       _applyTileBg(tiles[idx]);
-      // Safari suspends @keyframes on off-screen elements in scroll containers.
-      // Force-restart by setting animationName inline on each child, flushing
-      // the reflow per-element, then clearing the inline override.
-      if (idx !== lastAnimIdx) {
-        lastAnimIdx = idx;
-        tiles[idx].querySelectorAll('.css-anim *').forEach(function(el) {
-          el.style.animationName = 'none';
-          void el.offsetWidth;
-          el.style.animationName = '';
-        });
-      }
     }
 
     tiles.forEach(function(tile) {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -714,7 +714,7 @@ a.hero-tile:hover { color: rgba(255,255,255,.75); text-decoration: none !importa
 
 @media (max-width: 768px) {
     .hero-intro {
-        min-height: 32vh;
+        min-height: 22vh;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -722,6 +722,13 @@ a.hero-tile:hover { color: rgba(255,255,255,.75); text-decoration: none !importa
     .hero-intro h1 { margin: 0; }
     .hero-tile { width: 100%; min-height: 80vw; max-height: none; }
     .hero-tile p { padding-bottom: 1.3em; }
+    /* Tiles: use 48vh instead of 56vh so the section fits the visible
+       viewport on iOS where vh = large viewport (URL bar hidden). */
+    .container.scroll-test .hero-tile { height: 48vh; }
+    .container.scroll-test .hero-tile.is-active { height: calc(48vh + 40px); }
+    .container.scroll-test { min-height: calc(48vh + 40px); }
+    /* No extra bottom gap below the tile row on mobile. */
+    .tile-scroll-wrapper { padding-bottom: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/index.md
+++ b/index.md
@@ -42,7 +42,7 @@ galleryProjects:
 </h1>
 </div>
 
-<div style="padding-bottom: 20px;"></div>
+<div style="padding-bottom: 8px;"></div>
 
 {% include anim-01.html %}
 


### PR DESCRIPTION
## Summary

- **iOS animation fix**: `IntersectionObserver` now uses `root: the scroll row` so intersection is measured within the horizontal container. Without `root`, all tiles were always intersecting the document viewport, making the observer useless for detecting the active tile. Animation restart (inline `animationName = none` + reflow per element) moves from `update()` — which fires mid-swipe when WebKit ignores it — to the IO callback, which fires after the tile is settled into view.
- **Mobile excess space fix**: CSS tile heights switch from `56vh` to `48vh` on mobile because iOS `vh` = large viewport (URL bar hidden), causing the tile section to overflow the visible area. Wrapper `padding-bottom` also cleared on mobile. Hero-intro `min-height` reduced (32vh → 22vh) and bottom spacer trimmed (20px → 8px) to keep tiles in view without scrolling.

## Test plan

- [ ] On iOS Safari: swipe through tiles — each should play its CSS animation as it comes into view
- [ ] On iOS Chrome: same
- [ ] On iPhone: tiles should be visible without scrolling on initial load (no giant blank space below tiles)
- [ ] On desktop: animations and tile layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)