### PR TITLE
Hi page: fix swipe on all cards + handle colors in light mode

### DIFF
--- a/_includes/flickr.html
+++ b/_includes/flickr.html
@@ -76,7 +76,7 @@
   .flickr-handle:visited {
     font-weight: 400;
     font-size: 0.95rem;
-    color: #fff !important;
+    color: inherit;
     text-decoration: none;
   }
   .flickr-handle:hover {
@@ -85,9 +85,14 @@
   @media (prefers-color-scheme: dark) {
     .flickr-footer { border-bottom-color: rgba(255,255,255,0.1); }
     .flickr-loading { color: #666; }
+    .flickr-handle, .flickr-handle:visited { color: #fff; }
   }
   :root[data-theme="dark"] .flickr-footer { border-bottom-color: rgba(255,255,255,0.1); }
   :root[data-theme="dark"] .flickr-loading { color: #666; }
+  :root[data-theme="dark"] .flickr-handle,
+  :root[data-theme="dark"] .flickr-handle:visited { color: #fff; }
+  :root[data-theme="light"] .flickr-handle,
+  :root[data-theme="light"] .flickr-handle:visited { color: inherit; }
 </style>
 
 <script>

--- a/_includes/mastodon.html
+++ b/_includes/mastodon.html
@@ -52,8 +52,13 @@
   .mastodon-handle {
     font-weight: 400;
     font-size: 0.95rem;
-    color: #fff;
+    color: inherit;
   }
+  @media (prefers-color-scheme: dark) {
+    .mastodon-handle { color: #fff; }
+  }
+  :root[data-theme="dark"] .mastodon-handle { color: #fff; }
+  :root[data-theme="light"] .mastodon-handle { color: inherit; }
   .social-post-text { font-size: 1.05rem; line-height: 1.5; margin: 0; }
   .social-post-text.post-size-lg { font-size: 1.3rem; line-height: 1.4; }
   .social-post-text.post-size-xl { font-size: 1.65rem; line-height: 1.3; }

--- a/hi.md
+++ b/hi.md
@@ -580,7 +580,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
     if (animating) return;
     tsx = e.touches[0].clientX; tsy = e.touches[0].clientY;
     touchLocked = false; didDrag = false;
-  }, { passive: true });
+  }, { passive: true, capture: true });
   stack.addEventListener('touchmove', function (e) {
     var dx = e.touches[0].clientX - tsx;
     var dy = e.touches[0].clientY - tsy;
@@ -588,7 +588,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
     touchLocked = true;
     if (Math.abs(dx) > 4) didDrag = true;
     applyDrag(cards[current], dx);
-  }, { passive: true });
+  }, { passive: true, capture: true });
   stack.addEventListener('touchend', function (e) {
     var dx = e.changedTouches[0].clientX - tsx;
     var dy = e.changedTouches[0].clientY - tsy;
@@ -600,7 +600,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
       snapBack(card);
       setTimeout(function () { didDrag = false; }, 50);
     }
-  }, { passive: true });
+  }, { passive: true, capture: true });
 
   updateStack();
 })();


### PR DESCRIPTION
## Summary

- **Swipe fix (all cards)**: Touch listeners on `.hi-stack` now use `capture: true` so they fire before child element handlers. Previously, the Leaflet map (Strava card), Mastodon's clickable div, and Flickr's image links called `stopPropagation()` on touch events — the stack never saw the gesture, so only the plain Duolingo card responded to swipes.
- **Handle color fix**: Flickr `@handle` and Mastodon `@handle` were hardcoded `#fff` (invisible on light backgrounds in light mode). Now they inherit body text color in light mode; dark mode restores white via `@media (prefers-color-scheme: dark)` and `data-theme` selectors.

## Test plan

- [ ] On iPhone: swipe left/right on the Strava, Mastodon, Flickr, Book, and Music cards — all should fly off and advance
- [ ] Vertical scroll still works inside the Mastodon card
- [ ] In light mode: Flickr `@justinpocta` and Mastodon `@justinpocta` handles are readable (dark text)
- [ ] In dark mode: handles are white

🤖 Generated with [Claude Code](https://claude.com/claude-code)