### PR TITLE
Fix hi-card right-drag z-index tie; restart tile animations by cloning

### DIFF
--- a/_includes/anim-01.html
+++ b/_includes/anim-01.html
@@ -251,29 +251,57 @@
     if (active) _applyTileBg(active);
   }
 
-  // ── IntersectionObserver: greyscale reveal + CSS animation restart ──
+  // ── IntersectionObserver: greyscale reveal on touch devices ──
   // root: the scroll row, so intersection is measured within the horizontal
   // container (tiles off to the side = 0%, centered tile = ~100%).
-  // Animation restart fires here -- not in update() -- because IO fires after
-  // the tile is actually visible/settled, whereas scroll events fire mid-swipe
-  // when WebKit may still be animating the snap and ignores the restart.
   (function() {
     var row = document.getElementById('tile-scroll-row');
     if (!row) return;
-    var isTouchOnly = !window.matchMedia('(hover: hover)').matches;
-    var tiles = document.querySelectorAll('.hero-tile');
+    if (window.matchMedia('(hover: hover)').matches) return;
+    var tiles = row.querySelectorAll('.hero-tile');
     var observer = new IntersectionObserver(function(entries) {
       entries.forEach(function(entry) {
-        if (isTouchOnly) entry.target.classList.toggle('in-view', entry.isIntersecting);
-        if (!entry.isIntersecting) return;
-        entry.target.querySelectorAll('.css-anim *').forEach(function(el) {
-          el.style.animationName = 'none';
-          void el.offsetWidth;
-          el.style.animationName = '';
-        });
+        entry.target.classList.toggle('in-view', entry.isIntersecting);
       });
-    }, { root: row, threshold: 0.9 });
+    }, { root: row, threshold: 0.5 });
     tiles.forEach(function(tile) { observer.observe(tile); });
+  })();
+
+  // ── CSS animation restart: clone .css-anim after the scroll settles ──
+  // iOS WebKit suspends @keyframes on tiles that were offscreen inside the
+  // scroll row, and the inline animationName-reset trick fails when it runs
+  // mid-snap (IO at threshold 0.9 fires while momentum is still going).
+  // Debouncing past the last scroll event waits until the tile has settled
+  // onscreen; swapping in a deep clone hands WebKit brand-new nodes, which
+  // always start their animations from t=0 -- there is no suspended state
+  // for it to fail to resume.
+  (function() {
+    var row = document.getElementById('tile-scroll-row');
+    if (!row) return;
+    var tiles = Array.from(row.querySelectorAll('.hero-tile'));
+    var lastIdx = -1, timer = null;
+
+    function restartCentered() {
+      var center = row.scrollLeft + row.clientWidth / 2;
+      var idx = 0, minDist = Infinity;
+      tiles.forEach(function(tile, i) {
+        var dist = Math.abs((tile.offsetLeft + tile.offsetWidth / 2) - center);
+        if (dist < minDist) { minDist = dist; idx = i; }
+      });
+      if (idx === lastIdx) return;
+      lastIdx = idx;
+      var anim = tiles[idx].querySelector('.css-anim');
+      // Recruiting tile is JS-driven -- its timers hold references into the
+      // SVG, so cloning would freeze it.
+      if (!anim || anim.querySelector('#rec-grid')) return;
+      anim.parentNode.replaceChild(anim.cloneNode(true), anim);
+    }
+
+    row.addEventListener('scroll', function() {
+      clearTimeout(timer);
+      timer = setTimeout(restartCentered, 160);
+    });
+    timer = setTimeout(restartCentered, 300); // page may load scrolled mid-row
   })();
 
   // ── Drag-to-scroll ───────────────────────────────────────────────

--- a/hi.md
+++ b/hi.md
@@ -482,9 +482,14 @@ html[data-theme="dark"] p { color: #e8e8e8; }
       }
     } else if (dx > 0) {
       var progress = Math.min(1, dx / 160);
+      /* behind-1 also sits at z-index 2, and a tie resolves by DOM order --
+         so revealing prevCard at z2 only worked when it happened to come
+         later in the DOM (Duolingo, Mastodon). Lift prev above behind-1
+         and the dragged card above prev; both stay under the nav (z10). */
+      card.style.zIndex = '5';
       prevCard.style.transition = 'none';
       prevCard.style.opacity = '1';
-      prevCard.style.zIndex = '2';
+      prevCard.style.zIndex = '4';
       prevCard.style.transform = 'scale(' + (0.92 + 0.08 * progress) + ')';
       if (nextCard.style.transform) {
         nextCard.style.transition = '';
@@ -496,6 +501,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
   function snapBack(card) {
     card.style.transition = '';
     card.style.transform = '';
+    card.style.zIndex = '';
     var nextCard = cards[mod(current + 1, total)];
     nextCard.style.transition = '';
     nextCard.style.transform = '';


### PR DESCRIPTION
## Summary

**Hi page card stack (right-swipe showed wrong card on 4 of 6 cards)**
During a right-drag the revealed previous card was lifted to `z-index: 2` — the same z as behind-1 — and a z-index tie resolves by DOM order. So the reveal only looked correct when the previous card happened to come later in the DOM: Duolingo (prev = Strava) and Mastodon (prev = Duolingo). From Flickr/Book/Music/Strava, the previous card lost the tie, stayed hidden behind the next card during the drag, and then "swapped in" at release. Fix: revealed card goes to `z-index: 4`, dragged card to `5` (both under the nav buttons at z10); `snapBack` clears the new inline z-index.

**Homepage tiles (CSS animations never played on iOS)**
iOS WebKit suspends `@keyframes` on tiles that were offscreen inside the scroll row, and the inline `animationName`-reset trick fails when it runs mid-snap — the IntersectionObserver at threshold 0.9 fired while scroll momentum was still going. New approach: a scroll listener debounced 160ms past the last scroll event; once the tile has settled onscreen, its `.css-anim` subtree is swapped for a deep clone. Brand-new DOM nodes always start their animations from t=0 — there is no suspended state for WebKit to fail to resume. The JS-driven Recruiting tile is skipped (its timers hold references into the SVG). The IO reverts to greyscale-reveal duty only.

Note: with iOS **Reduce Motion** enabled, tile animations are still intentionally disabled by the `prefers-reduced-motion` CSS block — that's separate from this bug.

## Verified locally (desktop preview)

- Right-drag on Book card: Flickr revealed at z4 above Music (behind-1, z2); Flickr lands as active; zero leftover inline styles after release
- Scrolling to Jobs tile: `.css-anim` node identity changed (clone swapped in), `jobs-float` running on the fresh node
- Scrolling back to Recruiting tile: node NOT cloned, `#rec-grid` intact with all 21 shapes

## Test plan (on iPhone)

- [ ] Home: swipe through all tiles — OpenGov/Jobs/Workflows/Transcreation animations should play each time a tile settles
- [ ] Hi page: right-swipe on Flickr, Book, Music, Strava — the card revealed underneath during the drag should be the same card that lands
- [ ] Hi page: left-swipe still advances correctly on all cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)