### PR TITLE
Fix Duolingo streak sync: drop broken fields= query param

### DIFF
--- a/.github/workflows/duolingo-update.yml
+++ b/.github/workflows/duolingo-update.yml
@@ -40,7 +40,9 @@ jobs:
           picture = m.group(1) if m else existing.get('picture', '')
 
           # --- Streak + level from API (public, no auth needed most of the time) ---
-          api_url = 'https://www.duolingo.com/2017-06-30/users?username=texnology84&fields=username,streak,hasPlus,creationDate,learningLanguage,courses'
+          # No `fields=` filter -- Duolingo's API now returns {} (no "users" key)
+          # when that param is present, regardless of which fields are listed.
+          api_url = 'https://www.duolingo.com/2017-06-30/users?username=texnology84'
           api_req = urllib.request.Request(api_url, headers=HEADERS)
           try:
             with urllib.request.urlopen(api_req) as r:
@@ -56,6 +58,10 @@ jobs:
             member_since = datetime.datetime.utcfromtimestamp(creation_ts).strftime('%b %Y') if creation_ts else existing.get('member_since', '')
             courses = user.get('courses', [])
             fr_course = next((c for c in courses if c.get('learningLanguage') == 'fr'), None)
+            # Duolingo's API no longer exposes a per-course "level" field (it
+            # was replaced by "crowns", which returns a 9999 sentinel here --
+            # not a real count). This always falls through to the existing
+            # stored value now.
             out = {
               'username': user.get('username', existing.get('username', 'texnology84')),
               'streak': user.get('streak', existing.get('streak', 0)),

--- a/_data/duolingo.json
+++ b/_data/duolingo.json
@@ -1,10 +1,10 @@
 {
   "username": "texnology84",
-  "streak": 155,
+  "streak": 156,
   "picture": "https://d3gq3s1iyyx31w.cloudfront.net/static/render/bg/BackgroundColor-15/Body-1/ClothingColor-1/CostumeArtboard-0/Expression-1/EyeColor-1/FacialHair-2/FacialHairColor-2/Glasses-3/GlassesColor-3/HasCostume-0/Headwear-0/HeadwearColor-1/MainHair-61/MainHairColor-1/Nose%20Piercing-0/Piercings-0/SkinTone-5/Wrinkles-0/xxlarge",
   "hasPlus": true,
   "member_since": "Nov 2012",
   "learningLanguage": "fr",
   "french_level": 9,
-  "updated_at": "2026-07-28T10:41:00Z"
+  "updated_at": "2026-07-28T13:03:38Z"
 }


### PR DESCRIPTION
## Summary

The Duolingo streak card has been frozen at 155 since 2026-07-27 13:59 UTC even though three scheduled/manual workflow runs completed "successfully" since then. Root cause: Duolingo's public API now returns `{}` (no `users` key) whenever the `fields=` filter param is present in the request, regardless of which fields are listed. The script's fallback (`data.get('users', [])` → empty list → "API unavailable, keep existing data") silently absorbed this on every run — the workflow kept reporting success while quietly no-op'ing on the streak and only updating the avatar.

Verified directly:
- `curl .../users?username=texnology84&fields=...` → `{}`
- `curl .../users?username=texnology84` (no fields param) → full user object with `streak: 156`

Fix: drop the `fields=` param and request the full object, which still contains everything the script needs (`streak`, `hasPlus`, `creationDate`, `courses`). Also manually corrected `_data/duolingo.json`'s streak (155 → 156, the real live value) so the site isn't stale until the next 8am UTC scheduled run.

Noted in a comment: this same Duolingo API redesign also dropped the per-course `level` field the script reads (replaced by `crowns`, which returns an unusable `9999` sentinel for this account). `french_level` will stay frozen at its last real value (9) — a separate, smaller problem than the streak one, left as-is rather than displaying a nonsense number.

## Test plan

- [ ] Manually trigger the workflow (`gh workflow run duolingo-update.yml`) after merge and confirm the commit shows a real streak change, not just avatar/timestamp
- [ ] Hi/Now page Duolingo card shows the corrected streak

🤖 Generated with [Claude Code](https://claude.com/claude-code)