### PR TITLE
Weather card: use zip 11215 coordinates

### DIFF
--- a/_includes/weather.html
+++ b/_includes/weather.html
@@ -142,7 +142,7 @@
 
 <script>
 (function () {
-  var LAT = 40.6782, LON = -73.9442;
+  var LAT = 40.6669, LON = -73.9828; // zip 11215
 
   // WMO weather code -> [emoji, label]
   var CODES = {


### PR DESCRIPTION
## Summary

Swapped the hardcoded weather coordinates from general Brooklyn to zip 11215 (Park Slope) specifically: `40.6669, -73.9828`, looked up via zippopotam.us.

## Verified locally

Confirmed live via Open-Meteo — condition/temp now reflect the new coordinates (distinct "Partly Cloudy" reading vs. the prior location's "Overcast").

🤖 Generated with [Claude Code](https://claude.com/claude-code)