### PR TITLE
Fun page dark mode: fix white-on-white burger menu links

### DIFF
--- a/_includes/hi-page.html
+++ b/_includes/hi-page.html
@@ -23,6 +23,11 @@ body { background: transparent; }
   html body .masthead .site-title,
   html body .masthead .site-title:visited,
   html body .masthead .greedy-nav a { color: #f0f0f0 !important; }
+  /* .hidden-links (the burger dropdown) keeps the theme's plain white
+     background always -- it's a compiled Sass variable, not reactive to
+     prefers-color-scheme -- so forcing nav text to near-white above
+     also whited-out the dropdown's own links. Put them back to dark. */
+  html body .masthead .greedy-nav .hidden-links a { color: #333 !important; }
   .site-title::before { filter: invert(1); }
   h1, h2, h3, p { color: #e8e8e8; }
 }
@@ -31,6 +36,7 @@ html[data-theme="dark"] body { background: transparent !important; }
 html[data-theme="dark"] .masthead .site-title,
 html[data-theme="dark"] .masthead .site-title:visited,
 html[data-theme="dark"] .masthead .greedy-nav a { color: #f0f0f0 !important; }
+html[data-theme="dark"] .masthead .greedy-nav .hidden-links a { color: #333 !important; }
 html[data-theme="dark"] .site-title::before { filter: invert(1); }
 html[data-theme="dark"] h1,
 html[data-theme="dark"] h2,


### PR DESCRIPTION
## Summary

The burger dropdown (`.hidden-links`) always has a plain white background from the theme (a compiled Sass variable, not reactive to `prefers-color-scheme`). The dark-mode rule from the previous nav-contrast fix forces all nav link text to near-white — which also caught the dropdown's own links, making them invisible against its permanently-white card.

Added a higher-specificity override putting `.hidden-links a` back to `#333` specifically in dark mode, in both the `@media` block and the `[data-theme=dark]` block.

## Verified locally

- Dark mode, burger open: Work/Résumé/Fun/Info all render dark and legible against the white dropdown card
- Light mode: unaffected, still `#333` from the earlier fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)