### PR TITLE
Home: replace headline with new tagline, single fade-in

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,11 +34,9 @@ galleryProjects:
 <!-- <img src="../assets/img/profile-pic.jpg" style="overflow:hidden; border-radius:500px; height:200px; width:200px; float: left; margin-right:20px;"><br> -->
 <div class="hero-intro">
 <h1 style="text-align:center; text-wrap:balance; margin: 0;">
-  <span class="word-pop" style="animation-delay:0.0s">Empathy,</span>
-  <span class="word-pop" style="animation-delay:0.4s">collaboration,</span>
-  <span class="word-pop" style="animation-delay:0.8s">iteration,</span>
-  <span class="word-pop" style="animation-delay:1.2s">delight.</span>
-  <span class="word-pop" style="animation-delay:1.8s"><a href="info.html" class="rinse-repeat-link">Rinse &amp; Repeat</a>.</span>
+  <span class="word-pop" style="animation-delay:0.0s"><a href="info.html" class="rinse-repeat-link">Justin Pocta</a></span>
+  <span class="word-pop" style="animation-delay:0.4s">is a Product Designer</span>
+  <span class="word-pop" style="animation-delay:0.8s">living in Brooklyn, NY.</span>
 </h1>
 </div>
 

--- a/index.md
+++ b/index.md
@@ -34,9 +34,7 @@ galleryProjects:
 <!-- <img src="../assets/img/profile-pic.jpg" style="overflow:hidden; border-radius:500px; height:200px; width:200px; float: left; margin-right:20px;"><br> -->
 <div class="hero-intro">
 <h1 style="text-align:center; text-wrap:balance; margin: 0;">
-  <span class="word-pop" style="animation-delay:0.0s"><a href="info.html" class="rinse-repeat-link">Justin Pocta</a></span>
-  <span class="word-pop" style="animation-delay:0.4s">is a Product Designer</span>
-  <span class="word-pop" style="animation-delay:0.8s">living in Brooklyn, NY.</span>
+  <span class="word-pop" style="animation-delay:0.0s"><a href="info.html" class="rinse-repeat-link">Justin Pocta</a> is a Product Designer living in Brooklyn, NY.</span>
 </h1>
 </div>
 


### PR DESCRIPTION
## Summary

- Replaced the "Empathy, collaboration, iteration, delight. Rinse & Repeat." headline with "**Justin Pocta** is a Product Designer living in Brooklyn, NY." — "Justin Pocta" links to `/info`, same target the old "Rinse & Repeat" link used.
- Whole line fades/slides in together as one unit (single `.word-pop` span) rather than staggered phrase-by-phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)