### PR TITLE
Add minimum-distance filter and Run support to Strava integration

### DIFF
--- a/.github/workflows/strava-update.yml
+++ b/.github/workflows/strava-update.yml
@@ -1,4 +1,4 @@
-name: Update Strava Ride Data
+name: Update Strava Ride/Run Data
 
 on:
   schedule:
@@ -15,7 +15,7 @@ jobs:
         with:
           token: ${{ secrets.STRAVA_PUSH_TOKEN }}
 
-      - name: Fetch latest ride and write _data/strava.json
+      - name: Fetch latest ride/run and write _data/strava.json
         env:
           CLIENT_ID: ${{ secrets.STRAVA_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.STRAVA_CLIENT_SECRET }}
@@ -23,6 +23,8 @@ jobs:
         run: |
           python3 << 'PYEOF'
           import json, os, urllib.request, urllib.parse, datetime
+
+          MIN_DISTANCE_M = 1609  # ~1 mile -- skip short errand rides/runs
 
           # Refresh access token
           params = urllib.parse.urlencode({
@@ -37,34 +39,62 @@ jobs:
           access_token = token['access_token']
           print(f"Got access token (expires {token.get('expires_at')})")
 
-          # Fetch activities
+          # Fetch activities -- 50 instead of 20 since runs are rarer and a
+          # small window could miss the latest one entirely
           req = urllib.request.Request(
-            'https://www.strava.com/api/v3/athlete/activities?per_page=20',
+            'https://www.strava.com/api/v3/athlete/activities?per_page=50',
             headers={'Authorization': f'Bearer {access_token}'}
           )
           with urllib.request.urlopen(req) as r:
             activities = json.load(r)
 
-          # Latest ride
-          rides = [a for a in activities if a.get('type') == 'Ride' or a.get('sport_type') == 'Ride']
-          if not rides:
-            print('No rides found, keeping existing data')
-            exit(0)
+          def to_entry(a):
+            return {
+              'name': a.get('name', ''),
+              'distance': a.get('distance', 0),
+              'moving_time': a.get('moving_time', 0),
+              'start_date': a.get('start_date', ''),
+              'map_polyline': (a.get('map') or {}).get('summary_polyline', ''),
+            }
 
-          ride = rides[0]
-          data = {
-            'name': ride.get('name', ''),
-            'distance': ride.get('distance', 0),
-            'moving_time': ride.get('moving_time', 0),
-            'start_date': ride.get('start_date', ''),
-            'map_polyline': (ride.get('map') or {}).get('summary_polyline', ''),
-            'updated_at': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
-          }
+          def best_match(activity_type):
+            matches = [
+              a for a in activities
+              if (a.get('type') == activity_type or a.get('sport_type') == activity_type)
+              and a.get('distance', 0) >= MIN_DISTANCE_M
+            ]
+            return matches[0] if matches else None
+
+          # Load existing data so a slot with nothing new this run isn't
+          # wiped out -- e.g. a great run should stick around on the page
+          # until a newer qualifying run comes along, not disappear because
+          # today's fetch window didn't happen to contain one
+          existing = {}
+          if os.path.exists('_data/strava.json'):
+            with open('_data/strava.json') as f:
+              existing = json.load(f)
+            if 'ride' not in existing and existing.get('name'):
+              # Migrate legacy single-ride shape
+              existing = {'ride': {k: existing[k] for k in ('name', 'distance', 'moving_time', 'start_date', 'map_polyline') if k in existing}}
+
+          data = {'ride': existing.get('ride'), 'run': existing.get('run')}
+
+          for key, strava_type in (('ride', 'Ride'), ('run', 'Run')):
+            match = best_match(strava_type)
+            if match:
+              candidate = to_entry(match)
+              current = data.get(key)
+              if not current or candidate['start_date'] > current.get('start_date', ''):
+                data[key] = candidate
+
+          data['updated_at'] = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
           os.makedirs('_data', exist_ok=True)
           with open('_data/strava.json', 'w') as f:
             json.dump(data, f, indent=2)
-          print(f"Wrote: {data['name']} | {data['distance']}m | {data['moving_time']}s")
+          ride_name = (data.get('ride') or {}).get('name', '(none)')
+          run_name = (data.get('run') or {}).get('name', '(none)')
+          print(f"Ride: {ride_name} | Run: {run_name}")
           PYEOF
 
       - name: Commit if changed
@@ -75,6 +105,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes"
           else
-            git commit -m "Auto-update Strava ride data [skip ci]"
+            git commit -m "Auto-update Strava ride/run data [skip ci]"
             git push
           fi

--- a/_data/strava.json
+++ b/_data/strava.json
@@ -1,8 +1,10 @@
 {
-  "name": "Evening Ride",
-  "distance": 662.4,
-  "moving_time": 198,
-  "start_date": "2026-07-30T00:29:21Z",
-  "map_polyline": "_dfwFhuqbMgBvEi@nAIN?EABwA~D_CjG@AWz@iDdJGLGB?IJY\\[d@kA",
+  "ride": {
+    "name": "Evening Ride",
+    "distance": 662.4,
+    "moving_time": 198,
+    "start_date": "2026-07-30T00:29:21Z",
+    "map_polyline": "_dfwFhuqbMgBvEi@nAIN?EABwA~D_CjG@AWz@iDdJGLGB?IJY\\[d@kA"
+  },
   "updated_at": "2026-07-31T14:16:29Z"
 }

--- a/_includes/hi-page.html
+++ b/_includes/hi-page.html
@@ -411,7 +411,7 @@ html[data-theme="dark"] p { color: #e8e8e8; }
     </div>
 
     <div class="hi-card" id="hi-card-4">
-      {% include strava.html %}
+      {% include strava.html activity_key="ride" empty_label="No ride data yet" %}
     </div>
 
     <div class="hi-card" id="hi-card-5">
@@ -424,6 +424,10 @@ html[data-theme="dark"] p { color: #e8e8e8; }
 
     <div class="hi-card" id="hi-card-7">
       {% include weather.html %}
+    </div>
+
+    <div class="hi-card" id="hi-card-8">
+      {% include strava.html activity_key="run" empty_label="No run data yet" %}
     </div>
 
   </div>

--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -1,4 +1,6 @@
-{% assign ride = site.data.strava %}
+{% assign activity_key = include.activity_key | default: "ride" %}
+{% assign activity = site.data.strava[activity_key] %}
+{% assign empty_label = include.empty_label | default: "No ride data yet" %}
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <div class="strava-card">
   <div class="strava-card-header">
@@ -9,18 +11,18 @@
     <span class="strava-card-label">Strava</span>
   </div>
   <div class="strava-map-wrap">
-    <div class="strava-map-div" id="strava-map"></div>
-    {% if ride.name == "" %}
-    <div class="strava-map-empty">No ride data yet</div>
+    <div class="strava-map-div" id="strava-map-{{ activity_key }}"></div>
+    {% if activity.name == nil or activity.name == "" %}
+    <div class="strava-map-empty">{{ empty_label }}</div>
     {% endif %}
   </div>
   <div class="strava-card-footer">
-    <span class="strava-ride-name">{% if ride.name != "" %}{{ ride.name }}{% else %}—{% endif %}</span>
-    <span class="strava-ride-meta" id="strava-meta"></span>
+    <span class="strava-ride-name">{% if activity.name != nil and activity.name != "" %}{{ activity.name }}{% else %}—{% endif %}</span>
+    <span class="strava-ride-meta" id="strava-meta-{{ activity_key }}"></span>
   </div>
 </div>
 
-<script type="application/json" id="strava-data">{{ ride | jsonify }}</script>
+<script type="application/json" id="strava-data-{{ activity_key }}">{{ activity | jsonify }}</script>
 
 <style>
   .strava-card {
@@ -86,24 +88,24 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 (function () {
-  var raw = document.getElementById('strava-data');
+  var raw = document.getElementById('strava-data-{{ activity_key }}');
   if (!raw) return;
-  var ride;
-  try { ride = JSON.parse(raw.textContent); } catch (e) { return; }
-  if (!ride || !ride.name) return;
+  var activity;
+  try { activity = JSON.parse(raw.textContent); } catch (e) { return; }
+  if (!activity || !activity.name) return;
 
-  var meta = document.getElementById('strava-meta');
+  var meta = document.getElementById('strava-meta-{{ activity_key }}');
   if (meta) {
-    var mi = (ride.distance / 1609.34).toFixed(1) + ' mi';
-    var s = ride.moving_time;
+    var mi = (activity.distance / 1609.34).toFixed(1) + ' mi';
+    var s = activity.moving_time;
     var h = Math.floor(s / 3600);
     var m = Math.floor((s % 3600) / 60);
     var time = h > 0 ? h + 'h ' + m + 'm' : m + ' min';
-    var date = ride.start_date ? new Date(ride.start_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
+    var date = activity.start_date ? new Date(activity.start_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
     meta.textContent = [date, mi, time].filter(Boolean).join(' · ');
   }
 
-  if (!ride.map_polyline) return;
+  if (!activity.map_polyline) return;
 
   function decodePolyline(enc) {
     var pts = [], i = 0, lat = 0, lng = 0;
@@ -120,10 +122,10 @@
   }
 
   function initMap() {
-    var pts = decodePolyline(ride.map_polyline);
+    var pts = decodePolyline(activity.map_polyline);
     if (pts.length < 2) return;
 
-    var map = L.map('strava-map', {
+    var map = L.map('strava-map-{{ activity_key }}', {
       zoomControl: false,
       dragging: false,
       touchZoom: false,
@@ -148,7 +150,7 @@
     }).addTo(map);
   }
 
-  var mapDiv = document.getElementById('strava-map');
+  var mapDiv = document.getElementById('strava-map-{{ activity_key }}');
   if (mapDiv.offsetHeight > 0) {
     initMap();
   } else {


### PR DESCRIPTION
## Summary
- Skip activities under 1609m (~1mi) so short errand rides stop showing up
- Add Run support alongside Ride, each tracked and updated independently in `_data/strava.json`
- New card on `/hi/` for the latest qualifying run
- Bumped API fetch window from 20 to 50 activities since runs are rarer

## Test plan
- [x] Verified filter/preservation/legacy-migration logic locally with mock data
- [x] Verified Jekyll build + both cards render correctly with distinct DOM ids
- [ ] Trigger workflow manually post-merge to confirm live data updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)