### PR TITLE
Manually bump Duolingo French level to 10

### DIFF
--- a/_data/duolingo.json
+++ b/_data/duolingo.json
@@ -5,6 +5,6 @@
   "hasPlus": true,
   "member_since": "Nov 2012",
   "learningLanguage": "fr",
-  "french_level": 9,
-  "updated_at": "2026-08-04T10:45:35Z"
+  "french_level": 10,
+  "updated_at": "2026-08-04T15:30:00Z"
 }


### PR DESCRIPTION
## Summary
- Bump `french_level` to 10 -- this field is manually maintained now since Duolingo's public API no longer exposes it (documented in CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)