### PR TITLE
Fix Strava activity icon incorrectly turning white in dark mode

### DIFF
--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -98,13 +98,11 @@
     .strava-card-header { border-bottom-color: rgba(255,255,255,0.1); }
     .strava-card-footer { border-top-color: rgba(255,255,255,0.1); }
     .strava-ride-meta { color: #777; }
-    .strava-activity-icon { color: #fff; }
     .strava-ride-name { color: #fff; }
   }
   :root[data-theme="dark"] .strava-card-header { border-bottom-color: rgba(255,255,255,0.1); }
   :root[data-theme="dark"] .strava-card-footer { border-top-color: rgba(255,255,255,0.1); }
   :root[data-theme="dark"] .strava-ride-meta { color: #777; }
-  :root[data-theme="dark"] .strava-activity-icon { color: #fff; }
   :root[data-theme="dark"] .strava-ride-name { color: #fff; }
 </style>
 


### PR DESCRIPTION
## Summary
- Icon color was wrongly flipping to white in dark mode; it should stay a fixed neutral grey always. Only the title flips per theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)