### PR TITLE
Switch Strava map off CARTO, fade tiles for legibility, fix emoji crash

### DIFF
--- a/.github/workflows/strava-update.yml
+++ b/.github/workflows/strava-update.yml
@@ -97,8 +97,17 @@ jobs:
           data['updated_at'] = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
           os.makedirs('_data', exist_ok=True)
-          with open('_data/strava.json', 'w') as f:
-            json.dump(data, f, indent=2)
+          with open('_data/strava.json', 'w', encoding='utf-8') as f:
+            # ensure_ascii=False -- the default True writes non-ASCII
+            # (e.g. emoji in an activity name) as \uXXXX escapes, which
+            # for astral-plane characters means a UTF-16 surrogate
+            # pair. That's valid JSON, but Jekyll loads data files
+            # through Psych (YAML), which doesn't handle surrogate
+            # pairs and throws "invalid Unicode character escape
+            # code", crashing the entire site build. Writing the
+            # literal UTF-8 character instead sidesteps this.
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write('\n')
           ride_name = (data.get('ride') or {}).get('name', '(none)')
           run_name = (data.get('run') or {}).get('name', '(none)')
           print(f"Ride: {ride_name} | Run: {run_name}")

--- a/_data/strava.json
+++ b/_data/strava.json
@@ -1,7 +1,7 @@
 {
   "ride": {
     "id": 19954461768,
-    "name": "Trying to hit my annual target 4 months early \ud83d\ude05",
+    "name": "Trying to hit my annual target 4 months early 😅",
     "distance": 20736.7,
     "moving_time": 4500,
     "start_date": "2026-08-29T18:51:41Z",

--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -92,12 +92,12 @@
     padding: 0 3px;
   }
   .strava-map-div .leaflet-tile { border-radius: 0; overflow: visible; }
-  .strava-map-div .leaflet-tile-pane { filter: brightness(0.8) contrast(1.4); }
+  .strava-map-div .leaflet-tile-pane { filter: grayscale(1) brightness(1.35) contrast(0.6); }
   @media (prefers-color-scheme: dark) {
-    .strava-map-div .leaflet-tile-pane { filter: invert(1) hue-rotate(180deg) brightness(1.8) contrast(1.2); }
+    .strava-map-div .leaflet-tile-pane { filter: grayscale(1) contrast(0.6) invert(1) brightness(1.15); }
   }
-  :root[data-theme="light"] .strava-map-div .leaflet-tile-pane { filter: brightness(0.8) contrast(1.4); }
-  :root[data-theme="dark"] .strava-map-div .leaflet-tile-pane { filter: invert(1) hue-rotate(180deg) brightness(1.8) contrast(1.2); }
+  :root[data-theme="light"] .strava-map-div .leaflet-tile-pane { filter: grayscale(1) brightness(1.35) contrast(0.6); }
+  :root[data-theme="dark"] .strava-map-div .leaflet-tile-pane { filter: grayscale(1) contrast(0.6) invert(1) brightness(1.15); }
   @media (prefers-color-scheme: dark) {
     .strava-card-header { border-bottom-color: rgba(255,255,255,0.1); }
     .strava-card-footer { border-top-color: rgba(255,255,255,0.1); }

--- a/_includes/strava.html
+++ b/_includes/strava.html
@@ -85,8 +85,12 @@
   .strava-ride-meta {
     font-size: 0.82em; color: #888;
   }
-  .strava-map-div .leaflet-control-zoom,
-  .strava-map-div .leaflet-control-attribution { display: none !important; }
+  .strava-map-div .leaflet-control-zoom { display: none !important; }
+  .strava-map-div .leaflet-control-attribution {
+    font-size: 8px;
+    background: rgba(255,255,255,0.6);
+    padding: 0 3px;
+  }
   .strava-map-div .leaflet-tile { border-radius: 0; overflow: visible; }
   .strava-map-div .leaflet-tile-pane { filter: brightness(0.8) contrast(1.4); }
   @media (prefers-color-scheme: dark) {
@@ -154,12 +158,18 @@
       scrollWheelZoom: false,
       boxZoom: false,
       keyboard: false,
-      attributionControl: false,
+      attributionControl: true,
     });
 
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-      subdomains: 'abcd',
-      maxZoom: 20,
+    // CARTO's free basemaps now require an API key (they started
+    // watermarking unauthenticated tile requests). Switched to
+    // OpenStreetMap's standard tiles, which are free with no key --
+    // their usage policy does require visible attribution though, so
+    // that's kept on here instead of being hidden like before.
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      subdomains: 'abc',
+      maxZoom: 19,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     }).addTo(map);
 
     var route = L.polyline(pts, { color: '#FC4C02', weight: 3, opacity: 1 }).addTo(map);


### PR DESCRIPTION
## Summary
- CARTO now requires an API key for their free basemap tiles (watermarking unauthenticated requests) -- switch to OpenStreetMap standard tiles, free with no signup. Added the attribution their usage policy requires.
- Raw OSM tiles are much busier than the old CARTO basemap and buried the route line -- faded them down (grayscale + high brightness + low contrast) in both light/dark mode so the route reads clearly
- Fixed a real bug: an emoji in a Strava activity name got written as a `\uXXXX`-escaped UTF-16 surrogate pair (valid JSON), which Jekyll's Psych/YAML loader can't parse -- crashes the entire site build. Fixed both the live data file and the workflow's `json.dump` call (`ensure_ascii=False`)

## Test plan
- [x] Verified filter values live in both light and dark mode via browser screenshots
- [x] Verified the emoji fix by loading a mock file through Psych directly (same parser Jekyll uses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)